### PR TITLE
.NET Standard 2.0 Portage

### DIFF
--- a/src/Lavalink4NET.DSharpPlus/Lavalink4NET.DSharpPlus.csproj
+++ b/src/Lavalink4NET.DSharpPlus/Lavalink4NET.DSharpPlus.csproj
@@ -16,7 +16,7 @@
     <Company>Angelo Breuer</Company>
     <Copyright>Angelo Breuer</Copyright>
     <Product>Lavalink4NET</Product>
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <Description>
       A Lavalink wrapper for playing music using a discord bot.
       Integration with DSharpPlus Library.

--- a/src/Lavalink4NET.DSharpPlus/Lavalink4NET.DSharpPlus.csproj
+++ b/src/Lavalink4NET.DSharpPlus/Lavalink4NET.DSharpPlus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
     <PackageIconUrl>https://imgur.com/DbTYXxY.png</PackageIconUrl>

--- a/src/Lavalink4NET.Discord_NET/Lavalink4NET.Discord_NET.csproj
+++ b/src/Lavalink4NET.Discord_NET/Lavalink4NET.Discord_NET.csproj
@@ -16,7 +16,7 @@
     <PackageReleaseNotes>Compatible with Lavalink Server 3.0</PackageReleaseNotes>
     <PackageTags>lavalink,lavalink-wrapper,discord,discord-music,discord-music-bot,discord.net</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageIconUrl>https://imgur.com/DbTYXxY.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/angelobreuer/Lavalink4NET</RepositoryUrl>

--- a/src/Lavalink4NET.Discord_NET/Lavalink4NET.Discord_NET.csproj
+++ b/src/Lavalink4NET.Discord_NET/Lavalink4NET.Discord_NET.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Lavalink4NET.Discord.NET</PackageId>
     <Authors>Angelo Breuer</Authors>
     <Company>Angelo Breuer</Company>

--- a/src/Lavalink4NET.MemoryCache/Lavalink4NET.MemoryCache.csproj
+++ b/src/Lavalink4NET.MemoryCache/Lavalink4NET.MemoryCache.csproj
@@ -18,7 +18,7 @@
     <PackageProjectUrl></PackageProjectUrl>
     <RepositoryUrl>https://github.com/angelobreuer/Lavalink4NET</RepositoryUrl>
     <PackageIconUrl>https://imgur.com/DbTYXxY.png</PackageIconUrl>
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Lavalink4NET/Lavalink4NET.csproj
+++ b/src/Lavalink4NET/Lavalink4NET.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>7.1</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -32,5 +32,6 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/Lavalink4NET/Lavalink4NET.csproj
+++ b/src/Lavalink4NET/Lavalink4NET.csproj
@@ -16,7 +16,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>lavalink,lavalink-wrapper,discord,discord-music,discord-music-bot</PackageTags>
     <PackageReleaseNotes>Compatible with Lavalink Server 3.0</PackageReleaseNotes>
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <PackageProjectUrl />
     <PackageIconUrl>https://imgur.com/DbTYXxY.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/angelobreuer/Lavalink4NET</RepositoryUrl>

--- a/src/Lavalink4NET/LavalinkNode.cs
+++ b/src/Lavalink4NET/LavalinkNode.cs
@@ -551,7 +551,7 @@ namespace Lavalink4NET
             }
 
             // add player to the new node
-            node.Players.TryAdd(player.GuildId, player);
+            node.Players[player.GuildId] = player;
         }
     }
 }

--- a/src/Lavalink4NET/LavalinkSocket.cs
+++ b/src/Lavalink4NET/LavalinkSocket.cs
@@ -218,9 +218,9 @@ namespace Lavalink4NET
                 Logger?.Log(this, string.Format("Replaying {0} payload(s)...", _queue.Count), LogLevel.Debug);
 
                 // replay (FIFO)
-                while (_queue.TryDequeue(out var payload))
+                while (_queue.Count > 0)
                 {
-                    await SendPayloadAsync(payload);
+                    await SendPayloadAsync(_queue.Dequeue());
                 }
             }
 
@@ -421,7 +421,7 @@ namespace Lavalink4NET
 
             try
             {
-                result = await _webSocket.ReceiveAsync(_receiveBuffer, _cancellationTokenSource.Token);
+                result = await _webSocket.ReceiveAsync(new ArraySegment<byte>(_receiveBuffer, 0, _receiveBuffer.Length), _cancellationTokenSource.Token);
             }
             catch (WebSocketException ex)
             {

--- a/src/Lavalink4NET/Tracking/InactivityTrackingService.cs
+++ b/src/Lavalink4NET/Tracking/InactivityTrackingService.cs
@@ -211,8 +211,11 @@ namespace Lavalink4NET.Tracking
                 if (await IsInactiveAsync(player))
                 {
                     // add the player to tracking list
-                    if (_players.TryAdd(player.GuildId, DateTimeOffset.UtcNow + _options.DisconnectDelay))
+                    if (!_players.ContainsKey(player.GuildId))
                     {
+                        // mark as tracked
+                        _players.Add(player.GuildId, DateTimeOffset.UtcNow + _options.DisconnectDelay);
+
                         _logger.Log(this, string.Format("Tracked player {0} as inactive.", player.GuildId), LogLevel.Debug);
 
                         // trigger event


### PR DESCRIPTION
This pull requests includes the portage to .NET Standard 2.0 which brings up supports with:
- .NET Framework 4.6.1
- .NET Core 2.0
- and more.. (see: https://docs.microsoft.com/de-de/dotnet/standard/net-standard)