### PR TITLE
Fix player voice channel id changing after the bot is moved

### DIFF
--- a/src/Lavalink4NET/LavalinkNode.cs
+++ b/src/Lavalink4NET/LavalinkNode.cs
@@ -588,8 +588,7 @@ namespace Lavalink4NET
             }
 
             // reconnected to a voice channel
-            else if (args.OldVoiceState?.VoiceChannelId != null && args.VoiceState?.VoiceChannelId != null
-                && args.OldVoiceState.VoiceChannelId == args.VoiceState.VoiceChannelId)
+            else if (args.OldVoiceState?.VoiceChannelId != null && args.VoiceState?.VoiceChannelId != null)
             {
                 await player.UpdateAsync(args.VoiceState);
             }

--- a/src/Lavalink4NET/Player/LavalinkPlayer.cs
+++ b/src/Lavalink4NET/Player/LavalinkPlayer.cs
@@ -504,6 +504,7 @@ namespace Lavalink4NET.Player
             EnsureNotDestroyed();
 
             _voiceState = voiceState;
+            VoiceChannelId = voiceState.VoiceChannelId;
             return UpdateAsync();
         }
 


### PR DESCRIPTION
Fix player voice channel id changing after the bot is moved to another channel