### PR TITLE
Fix #51 and add additional statements to null out the CurrentTrack if…

### DIFF
--- a/src/Lavalink4NET/Lavalink4NET.xml
+++ b/src/Lavalink4NET/Lavalink4NET.xml
@@ -242,11 +242,6 @@
                 Gets the cluster node id.
             </summary>
         </member>
-        <member name="P:Lavalink4NET.Cluster.LavalinkClusterNode.Identifier">
-            <summary>
-                Gets the cluster node label.
-            </summary>
-        </member>
         <member name="P:Lavalink4NET.Cluster.LavalinkClusterNode.LastUsage">
             <summary>
                 Gets the coordinated universal time (UTC) point of the last usage of the node.
@@ -4395,16 +4390,16 @@
                 A set of default out-of-box inactivity trackers.
             </summary>
         </member>
-        <member name="P:Lavalink4NET.Tracking.DefaultInactivityTrackers.UsersInactivityTracker">
-            <summary>
-                An inactivity tracker ( <see cref="T:Lavalink4NET.Tracking.InactivityTracker"/>) which marks a player as
-                "inactive" when there are no users in the channel except the bot itself.
-            </summary>
-        </member>
         <member name="P:Lavalink4NET.Tracking.DefaultInactivityTrackers.ChannelInactivityTracker">
             <summary>
                 An inactivity tracker ( <see cref="T:Lavalink4NET.Tracking.InactivityTracker"/>) which marks a player as
                 "inactive" when the player is not playing a track.
+            </summary>
+        </member>
+        <member name="P:Lavalink4NET.Tracking.DefaultInactivityTrackers.UsersInactivityTracker">
+            <summary>
+                An inactivity tracker ( <see cref="T:Lavalink4NET.Tracking.InactivityTracker"/>) which marks a player as
+                "inactive" when there are no users in the channel except the bot itself.
             </summary>
         </member>
         <member name="T:Lavalink4NET.Tracking.InactivePlayerEventArgs">

--- a/src/Lavalink4NET/Player/LavalinkPlayer.cs
+++ b/src/Lavalink4NET/Player/LavalinkPlayer.cs
@@ -125,7 +125,9 @@ namespace Lavalink4NET.Player
         {
             await Client.SendVoiceUpdateAsync(GuildId, voiceChannelId, selfDeaf, selfMute);
             VoiceChannelId = voiceChannelId;
+
             State = PlayerState.NotPlaying;
+            CurrentTrack = null;
         }
 
         /// <summary>
@@ -199,6 +201,7 @@ namespace Lavalink4NET.Player
             {
                 // The track ended, set to not playing
                 State = PlayerState.NotPlaying;
+                CurrentTrack = null;
             }
 
             return Task.CompletedTask;
@@ -421,6 +424,9 @@ namespace Lavalink4NET.Player
             {
                 await DisconnectAsync(PlayerDisconnectCause.Stop);
             }
+
+            State = PlayerState.NotPlaying;
+            CurrentTrack = null;
         }
 
         /// <summary>
@@ -563,6 +569,7 @@ namespace Lavalink4NET.Player
                 // set initial player state to connected, if player was not connected or destroyed,
                 // see: https://github.com/angelobreuer/Lavalink4NET/issues/28
                 State = PlayerState.NotPlaying;
+                CurrentTrack = null;
             }
 
             // trigger event

--- a/src/Lavalink4NET/Player/QueuedLavalinkPlayer.cs
+++ b/src/Lavalink4NET/Player/QueuedLavalinkPlayer.cs
@@ -256,10 +256,10 @@ namespace Lavalink4NET.Player
                 // a track to play was found, dequeue and play
                 return PlayAsync(track!, false);
             }
-            // no tracks queued, disconnect if wanted
-            else if (_disconnectOnStop)
+            // no tracks queued, stop player and disconnect if specified
+            else
             {
-                return DisconnectAsync();
+                StopAsync(disconnect: _disconnectOnStop);
             }
 
             return Task.CompletedTask;

--- a/src/Lavalink4NET/Tracking/DefaultInactivityTrackers.cs
+++ b/src/Lavalink4NET/Tracking/DefaultInactivityTrackers.cs
@@ -29,12 +29,20 @@ namespace Lavalink4NET.Tracking
 {
     using System.Linq;
     using System.Threading.Tasks;
+    using Lavalink4NET.Player;
 
     /// <summary>
     ///     A set of default out-of-box inactivity trackers.
     /// </summary>
     public static class DefaultInactivityTrackers
     {
+        /// <summary>
+        ///     An inactivity tracker ( <see cref="InactivityTracker"/>) which marks a player as
+        ///     "inactive" when the player is not playing a track.
+        /// </summary>
+        public static InactivityTracker ChannelInactivityTracker { get; } = (player, _)
+            => Task.FromResult(player.State is PlayerState.NotPlaying);
+
         /// <summary>
         ///     An inactivity tracker ( <see cref="InactivityTracker"/>) which marks a player as
         ///     "inactive" when there are no users in the channel except the bot itself.
@@ -55,12 +63,5 @@ namespace Lavalink4NET.Tracking
             // check if there are no users in the channel (bot excluded)
             return userCount == 0;
         };
-
-        /// <summary>
-        ///     An inactivity tracker ( <see cref="InactivityTracker"/>) which marks a player as
-        ///     "inactive" when the player is not playing a track.
-        /// </summary>
-        public static InactivityTracker ChannelInactivityTracker { get; } = (player, _)
-            => Task.FromResult(player.State == Player.PlayerState.NotPlaying);
     }
 }


### PR DESCRIPTION
… needed

- Fixed that the CurrentTrack is not set to null if the player state is NotPlaying
- Fixed that the player state was set to `Playing` where it should not (e.g. after running SkipAsync without having tracks in queue).