### PR TITLE
Add ClusterNodeFactory, allow to override cluster node creation

### DIFF
--- a/src/Lavalink4NET/Cluster/ClusterNodeFactory.cs
+++ b/src/Lavalink4NET/Cluster/ClusterNodeFactory.cs
@@ -12,7 +12,6 @@ namespace Lavalink4NET.Cluster;
 /// <param name="logger">the logger</param>
 /// <param name="cache">an optional cache that caches track requests</param>
 /// <param name="id">the node number</param>
-public delegate T ClusterNodeFactory<T>(
+public delegate LavalinkClusterNode ClusterNodeFactory(
     LavalinkCluster cluster, LavalinkNodeOptions options, IDiscordClientWrapper client,
-    int id, IIntegrationCollection integrationCollection, ILogger? logger = null, ILavalinkCache? cache = null)
-    where T : LavalinkClusterNode;
+    int id, IIntegrationCollection integrationCollection, ILogger? logger = null, ILavalinkCache? cache = null);

--- a/src/Lavalink4NET/Cluster/ClusterNodeFactory.cs
+++ b/src/Lavalink4NET/Cluster/ClusterNodeFactory.cs
@@ -1,0 +1,18 @@
+using Lavalink4NET.Integrations;
+using Lavalink4NET.Logging;
+
+namespace Lavalink4NET.Cluster;
+
+/// <summary>
+///     A factory used to create cluster nodes.
+/// </summary>
+/// <param name="cluster">the cluster</param>
+/// <param name="options">the node options for connecting</param>
+/// <param name="client">the discord client</param>
+/// <param name="logger">the logger</param>
+/// <param name="cache">an optional cache that caches track requests</param>
+/// <param name="id">the node number</param>
+public delegate T ClusterNodeFactory<T>(
+    LavalinkCluster cluster, LavalinkNodeOptions options, IDiscordClientWrapper client,
+    int id, IIntegrationCollection integrationCollection, ILogger? logger = null, ILavalinkCache? cache = null)
+    where T : LavalinkClusterNode;

--- a/src/Lavalink4NET/Cluster/LavalinkCluster.cs
+++ b/src/Lavalink4NET/Cluster/LavalinkCluster.cs
@@ -52,7 +52,7 @@ public class LavalinkCluster : IAudioService, ILavalinkRestClient, IDisposable
     private bool _disposed;
     private bool _initialized;
     private volatile int _nodeId;
-    private readonly ClusterNodeFactory<LavalinkClusterNode> _nodeFactory;
+    private readonly ClusterNodeFactory _nodeFactory;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="LavalinkCluster"/> class.

--- a/src/Lavalink4NET/Cluster/LavalinkCluster.cs
+++ b/src/Lavalink4NET/Cluster/LavalinkCluster.cs
@@ -52,6 +52,7 @@ public class LavalinkCluster : IAudioService, ILavalinkRestClient, IDisposable
     private bool _disposed;
     private bool _initialized;
     private volatile int _nodeId;
+    private readonly ClusterNodeFactory<LavalinkClusterNode> _nodeFactory;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="LavalinkCluster"/> class.
@@ -84,6 +85,7 @@ public class LavalinkCluster : IAudioService, ILavalinkRestClient, IDisposable
         _nodesLock = new object();
         StayOnline = options.StayOnline;
         _nodes = options.Nodes.Select(CreateNode).ToList();
+        _nodeFactory = options.NodeFactory;
 
         Integrations = new IntegrationCollection();
     }
@@ -418,7 +420,7 @@ public class LavalinkCluster : IAudioService, ILavalinkRestClient, IDisposable
     /// </summary>
     /// <param name="nodeOptions">the node options</param>
     /// <returns>the created node</returns>
-    private LavalinkClusterNode CreateNode(LavalinkNodeOptions nodeOptions) => new(
+    private LavalinkClusterNode CreateNode(LavalinkNodeOptions nodeOptions) => _nodeFactory(
         cluster: this,
         options: nodeOptions,
         client: _client,

--- a/src/Lavalink4NET/Cluster/LavalinkClusterNode.cs
+++ b/src/Lavalink4NET/Cluster/LavalinkClusterNode.cs
@@ -85,7 +85,7 @@ public class LavalinkClusterNode : LavalinkNode
     /// <summary>
     ///     Gets the <see cref="ClusterNodeFactory"/> for this type.
     /// </summary>
-    public static ClusterNodeFactory<LavalinkClusterNode> ClusterNodeFactory { get; } =
+    public static ClusterNodeFactory ClusterNodeFactory { get; } =
         (cluster, options, client, id, integrationCollection, logger, cache) =>
             new LavalinkClusterNode(cluster, options, client, id, integrationCollection, logger, cache);
 

--- a/src/Lavalink4NET/Cluster/LavalinkClusterNode.cs
+++ b/src/Lavalink4NET/Cluster/LavalinkClusterNode.cs
@@ -36,7 +36,7 @@ using Lavalink4NET.Logging;
 /// <summary>
 ///     A clustered lavalink node with additional information.
 /// </summary>
-public sealed class LavalinkClusterNode : LavalinkNode
+public class LavalinkClusterNode : LavalinkNode
 {
     /// <summary>
     ///     Initializes a new instance of the <see cref="LavalinkNode"/> class.
@@ -81,6 +81,13 @@ public sealed class LavalinkClusterNode : LavalinkNode
         LastUsage = DateTimeOffset.MinValue;
         Integrations = integrationCollection;
     }
+
+    /// <summary>
+    ///     Gets the <see cref="ClusterNodeFactory"/> for this type.
+    /// </summary>
+    public static ClusterNodeFactory<LavalinkClusterNode> ClusterNodeFactory { get; } =
+        (cluster, options, client, id, integrationCollection, logger, cache) =>
+            new LavalinkClusterNode(cluster, options, client, id, integrationCollection, logger, cache);
 
     /// <summary>
     ///     Gets the cluster owning the node.

--- a/src/Lavalink4NET/Cluster/LavalinkClusterOptions.cs
+++ b/src/Lavalink4NET/Cluster/LavalinkClusterOptions.cs
@@ -50,7 +50,7 @@ public sealed class LavalinkClusterOptions
     /// <summary>
     ///     Gets or sets cluster node factory.
     /// </summary>
-    public ClusterNodeFactory<LavalinkClusterNode> NodeFactory { get; set; }
+    public ClusterNodeFactory NodeFactory { get; set; }
         = LavalinkClusterNode.ClusterNodeFactory;
 
     /// <summary>

--- a/src/Lavalink4NET/Cluster/LavalinkClusterOptions.cs
+++ b/src/Lavalink4NET/Cluster/LavalinkClusterOptions.cs
@@ -48,6 +48,12 @@ public sealed class LavalinkClusterOptions
         = Array.Empty<LavalinkNodeOptions>();
 
     /// <summary>
+    ///     Gets or sets cluster node factory.
+    /// </summary>
+    public ClusterNodeFactory<LavalinkClusterNode> NodeFactory { get; set; }
+        = LavalinkClusterNode.ClusterNodeFactory;
+
+    /// <summary>
     ///     Gets or sets a value indicating whether players should be moved to a new node if a
     ///     node disconnects accidentally.
     /// </summary>


### PR DESCRIPTION
This PR closes #94 
### Changes
- Make `LavalinkClusterNode` non sealed to allow override certain actions
- Add `ClusterNodeFactory`
- Add `ClusterNodeFactory` property to ClusterOptions