### PR TITLE
Improve logging in LavalinkNode

### DIFF
--- a/src/Lavalink4NET/LavalinkNodeOptions.cs
+++ b/src/Lavalink4NET/LavalinkNodeOptions.cs
@@ -99,12 +99,4 @@ public sealed class LavalinkNodeOptions : LavalinkRestOptions
     ///     If <see langword="true"/> then all "Connection to Lavalink Node failed" will be hidden from log
     /// </remarks>
     public bool SuppressReconnectionEntries { get; set; } = false;
-
-    /// <summary>
-    ///     Gets or sets value indicating whether all waiting before next reconnect shouldn't be logged
-    /// </summary>
-    /// <remarks>
-    ///     If <see langword="true"/> then all "Waiting X before next reconnect attempt" will be hidden from log
-    /// </remarks>
-    public bool HideWaitingBeforeNextReconnectFromLog { get; set; } = false;
 }

--- a/src/Lavalink4NET/LavalinkNodeOptions.cs
+++ b/src/Lavalink4NET/LavalinkNodeOptions.cs
@@ -91,4 +91,20 @@ public sealed class LavalinkNodeOptions : LavalinkRestOptions
     /// </summary>
     /// <remarks>This property defaults to <c>ws://localhost:8080/</c>.</remarks>
     public string WebSocketUri { get; set; } = "ws://localhost:8080/";
+
+    /// <summary>
+    ///     Gets or sets value indicating whether all duplicate reconnect attempts shouldn't be logged
+    /// </summary>
+    /// <remarks>
+    ///     If <see langword="true"/> then all "Connection to Lavalink Node failed" will be hidden from log
+    /// </remarks>
+    public bool HideReconnectionEntriesFromLog { get; set; } = false;
+
+    /// <summary>
+    ///     Gets or sets value indicating whether all waiting before next reconnect shouldn't be logged
+    /// </summary>
+    /// <remarks>
+    ///     If <see langword="true"/> then all "Waiting X before next reconnect attempt" will be hidden from log
+    /// </remarks>
+    public bool HideWaitingBeforeNextReconnectFromLog { get; set; } = false;
 }

--- a/src/Lavalink4NET/LavalinkNodeOptions.cs
+++ b/src/Lavalink4NET/LavalinkNodeOptions.cs
@@ -98,7 +98,7 @@ public sealed class LavalinkNodeOptions : LavalinkRestOptions
     /// <remarks>
     ///     If <see langword="true"/> then all "Connection to Lavalink Node failed" will be hidden from log
     /// </remarks>
-    public bool HideReconnectionEntriesFromLog { get; set; } = false;
+    public bool SuppressReconnectionEntries { get; set; } = false;
 
     /// <summary>
     ///     Gets or sets value indicating whether all waiting before next reconnect shouldn't be logged


### PR DESCRIPTION
Add `WebSocketUri` to all node logging entries, add `HideReconnectionEntriesFromLog` and `HideWaitingBeforeNextReconnectFromLog` to clear log from repeated messages