### PR TITLE
SoundCloud Track Artwork fix

### DIFF
--- a/src/Lavalink4NET/Artwork/ArtworkService.cs
+++ b/src/Lavalink4NET/Artwork/ArtworkService.cs
@@ -92,7 +92,8 @@ public class ArtworkService : IArtworkService, IDisposable
             }
         }
 
-        var requestUri = new Uri($"https://soundcloud.com/oembed?url={lavalinkTrack.TrackIdentifier}&format=json");
+        // the track uri is nullable, but in my testing it always returns one for soundcloud
+        var requestUri = new Uri($"https://soundcloud.com/oembed?url={lavalinkTrack.Uri.AbsoluteUri}&format=json");
         var thumbnailUri = await FetchTrackUriFromOEmbedCompatibleResourceAsync(requestUri, cancellationToken).ConfigureAwait(false);
 
         if (_cache is not null)

--- a/src/Lavalink4NET/Artwork/ArtworkService.cs
+++ b/src/Lavalink4NET/Artwork/ArtworkService.cs
@@ -93,8 +93,18 @@ public class ArtworkService : IArtworkService, IDisposable
         }
 
         // the track uri is nullable, but in my testing it always returns one for soundcloud
+        if (lavalinkTrack.Uri is null)
+            return null;
         var requestUri = new Uri($"https://soundcloud.com/oembed?url={lavalinkTrack.Uri.AbsoluteUri}&format=json");
-        var thumbnailUri = await FetchTrackUriFromOEmbedCompatibleResourceAsync(requestUri, cancellationToken).ConfigureAwait(false);
+        Uri? thumbnailUri;
+        try
+        {
+            thumbnailUri = await FetchTrackUriFromOEmbedCompatibleResourceAsync(requestUri, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException)
+        {
+            return null;
+        }
 
         if (_cache is not null)
         {


### PR DESCRIPTION
Changed track property that ArtworkService uses for soundcloud, it shouldn't throw a 404 now. There should probably also be a try/catch block to return null for the artwork instead of letting it bubble up, something which I can also quickly do.

closes #107 