### PR TITLE
update discord.net and use connectedusers property

### DIFF
--- a/src/Lavalink4NET.DiscordNet/DiscordClientWrapper.cs
+++ b/src/Lavalink4NET.DiscordNet/DiscordClientWrapper.cs
@@ -185,7 +185,7 @@ public sealed class DiscordClientWrapper : IDiscordClientWrapper, IDisposable
             return Task.FromResult(Enumerable.Empty<ulong>());
         }
 
-        return Task.FromResult(channel.Users.Select(s => s.Id));
+        return Task.FromResult(channel.ConnectedUsers.Select(s => s.Id));
     }
 
     /// <summary>

--- a/src/Lavalink4NET.DiscordNet/Lavalink4NET.DiscordNet.csproj
+++ b/src/Lavalink4NET.DiscordNet/Lavalink4NET.DiscordNet.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.WebSocket" Version="3.4.1" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="3.8.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes an issue where ``VoteSkipLavalinkPlayer`` uses an outdated property ``Users`` (from before text in voice channels was a thing) and uses the new property ``ConnectedUsers``, to get those who are actually in the voice channel itself.

Also updated discord.net