### PR TITLE
Cleanup `Lavalink4Net.DSharpPlus`.

### DIFF
--- a/src/Lavalink4NET.DSharpPlus/DSharpPlusUtilities.cs
+++ b/src/Lavalink4NET.DSharpPlus/DSharpPlusUtilities.cs
@@ -1,14 +1,12 @@
 namespace Lavalink4NET.DSharpPlus;
 
 using System.Reflection;
-using global::DSharpPlus;
 using global::DSharpPlus.Entities;
-using global::DSharpPlus.Net.WebSocket;
 
 /// <summary>
 ///     An utility for getting internal / private fields from DSharpPlus WebSocket Gateway Payloads.
 /// </summary>
-public static class DSharpUtil
+public static partial class DSharpPlusUtilities
 {
     /// <summary>
     ///     The internal "SessionId" property info in <see cref="DiscordVoiceState"/>.
@@ -19,16 +17,6 @@ public static class DSharpUtil
         .GetProperty("SessionId", BindingFlags.NonPublic | BindingFlags.Instance)!;
 #pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
 
-
-    /// <summary>
-    ///     The internal "_webSocketClient" field info in <see cref="DiscordClient"/>.
-    /// </summary>
-    // https://github.com/DSharpPlus/DSharpPlus/blob/master/DSharpPlus/Clients/DiscordClient.WebSocket.cs#L54
-    private static readonly FieldInfo _webSocketClientField = typeof(DiscordClient)
-#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
-        .GetField("_webSocketClient", BindingFlags.NonPublic | BindingFlags.Instance)!;
-#pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
-
     /// <summary>
     ///     Gets the internal "SessionId" property value of the specified <paramref name="voiceState"/>.
     /// </summary>
@@ -36,10 +24,4 @@ public static class DSharpUtil
     /// <returns>the "SessionId" value</returns>
     public static string GetSessionId(this DiscordVoiceState voiceState)
         => (string)_sessionIdProperty.GetValue(voiceState)!;
-
-    /// <summary>
-    ///     Gets the internal "_webSocketClient" field value of the specified <paramref name="client"/>.
-    /// </summary>
-    public static IWebSocketClient GetWebSocketClient(this DiscordClient client)
-        => (IWebSocketClient)_webSocketClientField.GetValue(client)!;
 }

--- a/src/Lavalink4NET.DSharpPlus/DiscordClientWrapper.cs
+++ b/src/Lavalink4NET.DSharpPlus/DiscordClientWrapper.cs
@@ -192,7 +192,7 @@ public sealed class DiscordClientWrapper : IDiscordClientWrapper, IDisposable
             CurrentUserId: discordClient.CurrentUser.Id,
             ShardCount: discordClient.ShardCount);
 
-        _readyTaskCompletionSource.SetResult(clientInformation);
+        _readyTaskCompletionSource.TrySetResult(clientInformation);
         return Task.CompletedTask;
     }
 

--- a/src/Lavalink4NET.DSharpPlus/DiscordClientWrapper.cs
+++ b/src/Lavalink4NET.DSharpPlus/DiscordClientWrapper.cs
@@ -1,27 +1,39 @@
 namespace Lavalink4NET.DSharpPlus;
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using global::DSharpPlus;
 using global::DSharpPlus.Entities;
 using global::DSharpPlus.EventArgs;
 using global::DSharpPlus.Exceptions;
+using global::DSharpPlus.Net.Abstractions;
 using Lavalink4NET.Clients;
 using Lavalink4NET.Clients.Events;
 using Lavalink4NET.Events;
 
+/// <summary>
+/// Wraps a <see cref="DiscordClient"/> or <see cref="DiscordShardedClient"/> instance.
+/// </summary>
 public sealed class DiscordClientWrapper : IDiscordClientWrapper, IDisposable
 {
+    /// <inheritdoc/>
+    public event AsyncEventHandler<VoiceServerUpdatedEventArgs>? VoiceServerUpdated;
+
+    /// <inheritdoc/>
+    public event AsyncEventHandler<VoiceStateUpdatedEventArgs>? VoiceStateUpdated;
+
     private readonly object _client; // either DiscordShardedClient or DiscordClient
     private readonly TaskCompletionSource<ClientInformation> _readyTaskCompletionSource;
     private bool _disposed;
 
+    /// <summary>
+    /// Creates a new instance of <see cref="DiscordClientWrapper"/>.
+    /// </summary>
+    /// <param name="discordClient">The Discord Client to wrap.</param>
     public DiscordClientWrapper(DiscordClient discordClient)
     {
         ArgumentNullException.ThrowIfNull(discordClient);
@@ -34,49 +46,20 @@ public sealed class DiscordClientWrapper : IDiscordClientWrapper, IDisposable
         discordClient.Ready += OnClientReady;
     }
 
-    public DiscordClientWrapper(DiscordShardedClient discordClient)
+    /// <summary>
+    /// Creates a new instance of <see cref="DiscordClientWrapper"/>.
+    /// </summary>
+    /// <param name="shardedDiscordClient">The Sharded Discord Client to wrap.</param>
+    public DiscordClientWrapper(DiscordShardedClient shardedDiscordClient)
     {
-        ArgumentNullException.ThrowIfNull(discordClient);
+        ArgumentNullException.ThrowIfNull(shardedDiscordClient);
 
-        _client = discordClient;
+        _client = shardedDiscordClient;
         _readyTaskCompletionSource = new TaskCompletionSource<ClientInformation>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        discordClient.VoiceStateUpdated += OnVoiceStateUpdated;
-        discordClient.VoiceServerUpdated += OnVoiceServerUpdated;
-        discordClient.Ready += OnClientReady;
-    }
-
-    /// <inheritdoc/>
-    public event AsyncEventHandler<VoiceServerUpdatedEventArgs>? VoiceServerUpdated;
-
-    /// <inheritdoc/>
-    public event AsyncEventHandler<VoiceStateUpdatedEventArgs>? VoiceStateUpdated;
-
-    /// <inheritdoc/>
-    public void Dispose()
-    {
-        if (_disposed)
-        {
-            return;
-        }
-
-        _disposed = true;
-
-        if (_client is DiscordClient discordClient)
-        {
-            discordClient.VoiceStateUpdated -= OnVoiceStateUpdated;
-            discordClient.VoiceServerUpdated -= OnVoiceServerUpdated;
-            discordClient.Ready -= OnClientReady;
-        }
-        else
-        {
-            var shardedClient = Unsafe.As<object, DiscordShardedClient>(ref Unsafe.AsRef(_client));
-
-            shardedClient.VoiceStateUpdated -= OnVoiceStateUpdated;
-            shardedClient.VoiceServerUpdated -= OnVoiceServerUpdated;
-            shardedClient.Ready -= OnClientReady;
-        }
-
+        shardedDiscordClient.VoiceStateUpdated += OnVoiceStateUpdated;
+        shardedDiscordClient.VoiceServerUpdated += OnVoiceServerUpdated;
+        shardedDiscordClient.Ready += OnClientReady;
     }
 
     /// <inheritdoc/>
@@ -95,35 +78,31 @@ public sealed class DiscordClientWrapper : IDiscordClientWrapper, IDisposable
             channel = await GetClientForGuild(guildId)
                 .GetChannelAsync(voiceChannelId)
                 .ConfigureAwait(false);
+
+            if (channel is null)
+            {
+                return ImmutableArray<ulong>.Empty;
+            }
         }
-        catch (UnauthorizedException)
+        catch (DiscordException)
         {
-            // The channel was possibly deleted
+            // Jan 23, 2024, OoLunar: You should be logging this!!
+            // Or handling it in some way, not just silently ignoring it.
             return ImmutableArray<ulong>.Empty;
         }
 
-        if (channel is null)
+        var filteredUsers = ImmutableArray.CreateBuilder<ulong>(channel.Users.Count);
+        foreach (DiscordMember member in channel.Users)
         {
-            return ImmutableArray<ulong>.Empty;
+            // Always skip the current user.
+            // If we're not including bots and the member is a bot, skip them.
+            if (!member.IsCurrent || includeBots || !member.IsBot)
+            {
+                filteredUsers.Add(member.Id);
+            }
         }
 
-        var usersEnumerable = channel.Users.AsEnumerable();
-
-        if (includeBots)
-        {
-            var currentUserId = _client is DiscordClient discordClient
-                ? discordClient.CurrentUser.Id
-                : ((DiscordShardedClient)_client).CurrentUser.Id;
-
-            usersEnumerable = usersEnumerable.Where(x => x.Id != currentUserId);
-        }
-        else
-        {
-            usersEnumerable = usersEnumerable.Where(x => !x.IsBot);
-        }
-
-
-        return usersEnumerable.Select(s => s.Id).ToImmutableArray();
+        return filteredUsers.ToImmutable();
     }
 
     /// <inheritdoc/>
@@ -136,14 +115,15 @@ public sealed class DiscordClientWrapper : IDiscordClientWrapper, IDisposable
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-
-        var payload = new JsonObject();
-        var data = new VoiceStateUpdatePayload(guildId, voiceChannelId, selfMute, selfDeaf);
-
-        payload.Add("op", 4);
-        payload.Add("d", JsonSerializer.SerializeToNode(data));
-
-        await GetClientForGuild(guildId).GetWebSocketClient().SendMessageAsync(payload.ToString()).ConfigureAwait(false);
+#pragma warning disable CS0618 // This method should not be used unless you know what you're doing. Instead, look towards the other explicitly implemented methods which come with client-side validation.
+        // Jan 23, 2024, OoLunar: We're telling Discord that we're joining a voice channel.
+        // At the time of writing, both DSharpPlus.VoiceNext and DSharpPlus.VoiceLink™
+        // use this method to send voice state updates.
+        await GetClientForGuild(guildId).SendPayloadAsync(
+            GatewayOpCode.VoiceStateUpdate,
+            JsonSerializer.Serialize(new VoiceStateUpdatePayload(guildId, voiceChannelId, selfMute, selfDeaf))
+        ).ConfigureAwait(false);
+#pragma warning restore CS0618 // This method should not be used unless you know what you're doing. Instead, look towards the other explicitly implemented methods which come with client-side validation.
     }
 
     /// <inheritdoc/>
@@ -153,73 +133,94 @@ public sealed class DiscordClientWrapper : IDiscordClientWrapper, IDisposable
         return new(_readyTaskCompletionSource.Task.WaitAsync(cancellationToken));
     }
 
-    private DiscordClient GetClientForGuild(ulong guildId)
+    /// <inheritdoc/>
+    public void Dispose()
     {
-        if (_client is DiscordClient discordClient)
+        if (_disposed)
         {
-            return discordClient;
+            return;
         }
 
-        return Unsafe.As<object, DiscordShardedClient>(ref Unsafe.AsRef(_client)).GetShard(guildId);
+        _disposed = true;
+        if (_client is DiscordClient discordClient)
+        {
+            discordClient.VoiceStateUpdated -= OnVoiceStateUpdated;
+            discordClient.VoiceServerUpdated -= OnVoiceServerUpdated;
+            discordClient.Ready -= OnClientReady;
+        }
+        else if (_client is DiscordShardedClient shardedClient)
+        {
+            shardedClient.VoiceStateUpdated -= OnVoiceStateUpdated;
+            shardedClient.VoiceServerUpdated -= OnVoiceServerUpdated;
+            shardedClient.Ready -= OnClientReady;
+        }
     }
+
+    private DiscordClient GetClientForGuild(ulong guildId) => _client is DiscordClient discordClient
+        ? discordClient
+        : ((DiscordShardedClient)_client).GetShard(guildId);
 
     private Task OnClientReady(DiscordClient discordClient, ReadyEventArgs eventArgs)
     {
         ArgumentNullException.ThrowIfNull(discordClient);
         ArgumentNullException.ThrowIfNull(eventArgs);
-
-        var clientInformation = new ClientInformation(
+        ClientInformation clientInformation = new(
             Label: "DSharpPlus",
             CurrentUserId: discordClient.CurrentUser.Id,
-            ShardCount: discordClient.ShardCount);
+            ShardCount: discordClient.ShardCount
+        );
 
-        _readyTaskCompletionSource.TrySetResult(clientInformation);
-
+        _readyTaskCompletionSource.SetResult(clientInformation);
         return Task.CompletedTask;
     }
 
-    private Task OnVoiceServerUpdated(DiscordClient discordClient, VoiceServerUpdateEventArgs voiceServerUpdateEventArgs)
+    private async Task OnVoiceServerUpdated(DiscordClient discordClient, VoiceServerUpdateEventArgs voiceServerUpdateEventArgs)
     {
         ArgumentNullException.ThrowIfNull(discordClient);
         ArgumentNullException.ThrowIfNull(voiceServerUpdateEventArgs);
 
         var server = new VoiceServer(
             Token: voiceServerUpdateEventArgs.VoiceToken,
-            Endpoint: voiceServerUpdateEventArgs.Endpoint);
+            Endpoint: voiceServerUpdateEventArgs.Endpoint
+        );
 
         var eventArgs = new VoiceServerUpdatedEventArgs(
             guildId: voiceServerUpdateEventArgs.Guild.Id,
-            voiceServer: server);
+            voiceServer: server
+        );
 
-        return VoiceServerUpdated.InvokeAsync(this, eventArgs).AsTask();
+        await VoiceServerUpdated.InvokeAsync(this, eventArgs);
     }
-    private Task OnVoiceStateUpdated(DiscordClient discordClient, VoiceStateUpdateEventArgs voiceStateUpdateEventArgs)
+
+    private async Task OnVoiceStateUpdated(DiscordClient discordClient, VoiceStateUpdateEventArgs voiceStateUpdateEventArgs)
     {
         ArgumentNullException.ThrowIfNull(discordClient);
         ArgumentNullException.ThrowIfNull(voiceStateUpdateEventArgs);
 
         // session id is the same as the resume key so DSharpPlus should be able to give us the
         // session key in either before or after voice state
-        var sessionId = voiceStateUpdateEventArgs.Before?.GetSessionId()
-            ?? voiceStateUpdateEventArgs.After.GetSessionId();
+        var sessionId = voiceStateUpdateEventArgs.Before?.GetSessionId() ?? voiceStateUpdateEventArgs.After.GetSessionId();
 
         // create voice state
         var voiceState = new VoiceState(
             VoiceChannelId: voiceStateUpdateEventArgs.After?.Channel?.Id,
-            SessionId: sessionId);
+            SessionId: sessionId
+        );
 
         var oldVoiceState = new VoiceState(
             VoiceChannelId: voiceStateUpdateEventArgs.Before?.Channel?.Id,
-            SessionId: sessionId);
+            SessionId: sessionId
+        );
 
         // invoke event
-        var eventArgs = new VoiceStateUpdatedEventArgs(
+        VoiceStateUpdatedEventArgs eventArgs = new(
             guildId: voiceStateUpdateEventArgs.Guild.Id,
             userId: voiceStateUpdateEventArgs.User.Id,
             isCurrentUser: voiceStateUpdateEventArgs.User.Id == discordClient.CurrentUser.Id,
             oldVoiceState: oldVoiceState,
-            voiceState: voiceState);
+            voiceState: voiceState
+        );
 
-        return VoiceStateUpdated.InvokeAsync(this, eventArgs).AsTask();
+        await VoiceStateUpdated.InvokeAsync(this, eventArgs);
     }
 }

--- a/src/Lavalink4NET.DSharpPlus/Lavalink4NET.DSharpPlus.csproj
+++ b/src/Lavalink4NET.DSharpPlus/Lavalink4NET.DSharpPlus.csproj
@@ -1,24 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Library</OutputType>
-	  <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <!-- Package Description -->
-    <Description>
-		High performance Lavalink wrapper for .NET | Add powerful audio playback to your DSharpPlus-based applications with this integration for Lavalink4NET. Suitable for end users developing with DSharpPlus.
-	</Description>
-
+    <Description>High performance Lavalink wrapper for .NET | Add powerful audio playback to your DSharpPlus-based applications with this integration for Lavalink4NET. Suitable for end users developing with DSharpPlus.</Description>
     <PackageTags>lavalink,lavalink-wrapper,discord,discord-music,discord-music-bot,dsharpplus</PackageTags>
-
     <!-- Documentation -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="4.4.1" />
-    <ProjectReference Include="..\Lavalink4NET\Lavalink4NET.csproj" />
+    <PackageReference Include="DSharpPlus" Version="4.4.6" />
+    <ProjectReference Include="../Lavalink4NET/Lavalink4NET.csproj" />
   </ItemGroup>
-
   <Import Project="../Lavalink4NET.targets" />
 </Project>

--- a/src/Lavalink4NET.DSharpPlus/ServiceCollectionExtensions.cs
+++ b/src/Lavalink4NET.DSharpPlus/ServiceCollectionExtensions.cs
@@ -4,8 +4,16 @@ using System;
 using Lavalink4NET.DSharpPlus;
 using Microsoft.Extensions.DependencyInjection;
 
+/// <summary>
+/// A collection of extension methods for <see cref="IServiceCollection"/>.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Adds the Lavalink4NET DSharpPlus extension to the service collection.
+    /// </summary>
+    /// <param name="services">The service collection to add the extension to.</param>
+    /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddLavalink(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);

--- a/src/Lavalink4NET.DSharpPlus/VoiceStateUpdatePayload.cs
+++ b/src/Lavalink4NET.DSharpPlus/VoiceStateUpdatePayload.cs
@@ -2,8 +2,20 @@ namespace Lavalink4NET.DSharpPlus;
 
 using System.Text.Json.Serialization;
 
-internal sealed class VoiceStateUpdatePayload
+internal readonly record struct VoiceStateUpdatePayload
 {
+    [JsonPropertyName("guild_id")]
+    public ulong GuildId { get; init; }
+
+    [JsonPropertyName("channel_id")]
+    public ulong? ChannelId { get; init; }
+
+    [JsonPropertyName("self_mute")]
+    public bool IsSelfMuted { get; init; }
+
+    [JsonPropertyName("self_deaf")]
+    public bool IsSelfDeafened { get; init; }
+
     public VoiceStateUpdatePayload(ulong guildId, ulong? channelId, bool isSelfMuted = false, bool isSelfDeafened = false)
     {
         GuildId = guildId;
@@ -11,16 +23,4 @@ internal sealed class VoiceStateUpdatePayload
         IsSelfMuted = isSelfMuted;
         IsSelfDeafened = isSelfDeafened;
     }
-
-    [JsonPropertyName("guild_id")]
-    public ulong GuildId { get; }
-
-    [JsonPropertyName("channel_id")]
-    public ulong? ChannelId { get; }
-
-    [JsonPropertyName("self_mute")]
-    public bool IsSelfMuted { get; }
-
-    [JsonPropertyName("self_deaf")]
-    public bool IsSelfDeafened { get; }
 }


### PR DESCRIPTION
# Summary
- Turn `VoiceStateUpdatePayload` into a readonly struct as it's lifetime is short and it's only referenced once
- Update DSharpPlus to 4.4.6
- Rename `DSharpUtils` to `DSharpPlusUtilities`
- Remove `DSharpPlusUtilities.GetWebSocketClient` in lieu of `DiscordClient.SendPayloadAsync<T>(GatewayOpCode opCode, T data)`
- Update `GetChannelUsersAsync` to catch any `DiscordException` instead of just `UnauthorizedException`.
- Update `GetChannelUsersAsync` to iterate once over `DiscordChannel.Users`
- Remove premature optimization on `GetClientForGuild`
- Formatting
- Documentation

# Notes
All changes are entirely untested.