### PR TITLE
refactor!: Improve strict search

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       run: dotnet restore src/Lavalink4NET.sln
       
     - name: Build
-      run: dotnet build src/Lavalink4NET.sln --no-restore --configuration ${{ matrix.configuration }} /property:Version=4.0.8
+      run: dotnet build src/Lavalink4NET.sln --no-restore --configuration ${{ matrix.configuration }} /property:Version=4.0.9
 
     - name: Run tests
       working-directory: ci

--- a/src/Lavalink4NET.Rest/Entities/Tracks/StrictSearchBehavior.cs
+++ b/src/Lavalink4NET.Rest/Entities/Tracks/StrictSearchBehavior.cs
@@ -1,0 +1,124 @@
+﻿namespace Lavalink4NET.Rest.Entities.Tracks;
+
+public enum StrictSearchBehavior : byte
+{
+    /// <summary>
+    ///     Denotes that strict search will throw if a query is found that might be ambiguous.
+    /// </summary>
+    /// <remarks>
+    ///     <example>
+    ///         The following queries would throw an exception: 
+    ///         <list type="bullet">
+    ///             <item>`ytsearch:abc`</item>
+    ///             <item>`spsearch:abc`</item>
+    ///         </list>
+    ///         
+    ///         The following query would not throw an exception: 
+    ///         <list type="bullet">
+    ///             <item>`abc`</item>
+    ///             <item>`https://example.com/test.mp3`</item>
+    ///             <item>`https://youtube.com/watch?v=[...]`</item>
+    ///             <item>`https://open.spotify.com/playlist/[...]`</item>
+    ///         </list>
+    ///     </example>
+    ///     
+    ///     <example>
+    ///         The following queries will be converted to resolve as the following queries:
+    ///         <list type="bullet">
+    ///             <item>(Search Mode: `ytsearch`) `abc` -> `ytsearch:abc`;</item>
+    ///             <item>(Search Mode: `&lt;none&gt;`) `abc` -> `abc`;</item>
+    ///         </list>
+    ///     </example>
+    /// </remarks>
+    Throw,
+
+    /// <summary>
+    ///     Denotes that if strict search would be triggered, the query will be prefixed with
+    ///     the specified search mode to avoid ambiguous results.
+    /// </summary>
+    /// <remarks>
+    ///     <example>
+    ///         The following queries will be converted to resolve as the following queries (Search Mode here is ytsearch):
+    ///         <list type="bullet">
+    ///             <item>`abc` -> `ytsearch:abc`;</item>
+    ///             <item>`PR: abc` -> `ytsearch:PR: abc`;</item>
+    ///             <item>`ytsearch:abc` -> `ytsearch:ytsearch:abc`</item>
+    ///             <item>`spsearch:abc` -> `ytsearch:spsearch:abc`</item>
+    ///             <item>`https://example.com/test.mp3` -> `https://example.com/test.mp3`</item>
+    ///             <item>`https://youtube.com/watch?v=[...]` -> `https://youtube.com/watch?v=[...]`</item>
+    ///             <item>`https://open.spotify.com/playlist/[...]` -> `https://open.spotify.com/playlist/[...]`</item>
+    ///         </list>
+    ///     </example>
+    /// </remarks>
+    Resolve,
+
+    /// <summary>
+    ///     Denotes that strict search will throw if a query is found that might be not using the specified search mode.
+    ///     <see cref="Implicit"/> always requires an explicit search mode to be specified.
+    /// </summary>
+    /// <remarks>
+    ///     <example>
+    ///         The following queries would throw an exception: 
+    ///         <list type="bullet">
+    ///             <item>`ytsearch:abc`</item>
+    ///             <item>`spsearch:abc`</item>
+    ///             <item>`a:abc`</item>
+    ///             <item>`https://example.com/test.mp3`</item>
+    ///             <item>`https://youtube.com/watch?v=[...]`</item>
+    ///             <item>`https://open.spotify.com/playlist/[...]`</item>
+    ///         </list>
+    ///         
+    ///         The following queries would not throw an exception: 
+    ///         <list type="bullet">
+    ///             <item>`abc`</item>
+    ///             <item>`def`</item>
+    ///         </list>
+    ///     </example>
+    /// </remarks>
+    Implicit,
+
+    /// <summary>
+    ///     Denotes that if strict search would be triggered, the query will be prefixed with
+    ///     the specified search mode to avoid ambiguous results.
+    /// </summary>
+    /// <remarks>
+    ///     <example>
+    ///         The following queries will be converted to resolve as the following queries (Search Mode here is `ytsearch`):
+    ///         <list type="bullet">
+    ///             <item>`abc` -> `ytsearch:abc`;</item>
+    ///             <item>`PR: abc` -> `ytsearch:PR: abc`;</item>
+    ///             <item>`ytsearch:abc` -> `ytsearch:ytsearch:abc`</item>
+    ///             <item>`spsearch:abc` -> `ytsearch:spsearch:abc`</item>
+    ///             <item>`https://example.com/test.mp3` -> `ytsearch:https://example.com/test.mp3`</item>
+    ///             <item>`https://youtube.com/watch?v=[...]` -> `ytsearch:https://youtube.com/watch?v=[...]`</item>
+    ///             <item>`https://youtube.com/watch?v=[...]` -> `ytsearch:https://youtube.com/watch?v=[...]`</item>
+    ///             <item>`https://open.spotify.com/playlist/[...]` -> `ytsearch:https://open.spotify.com/playlist/[...]`</item>
+    ///         </list>
+    ///     </example>
+    /// </remarks>
+    Explicit,
+
+    /// <summary>
+    ///     Denotes that strict search will be disabled. If no search mode is specified, the query will be passed through. If a search
+    ///     mode is specified and none set in the query, the query will be prefixed with the specified search mode, in case the query is not a direct URI.
+    /// </summary>
+    /// <remarks>
+    ///     If you want to have full control over your queries, choose <see cref="Passthrough"/> and specify no search mode, in
+    ///     that way Lavalink4NET will not process your query in any way.
+    /// 
+    ///     <example>
+    ///         The following queries will be converted to resolve as the following queries (Search Mode here is `ytsearch`):
+    ///         <list type="bullet">
+    ///             <item>`abc` -> `ytsearch:abc`;</item>
+    ///             <item>`PR: abc` -> `PR: abc`;</item>
+    ///             <item>`ytsearch:abc` -> `ytsearch:abc`</item>
+    ///             <item>`spsearch:abc` -> `spsearch:abc`</item>
+    ///             <item>`https://example.com/test.mp3` -> `https://example.com/test.mp3`</item>
+    ///             <item>`https://youtube.com/watch?v=[...]` -> `https://youtube.com/watch?v=[...]`</item>
+    ///             <item>`https://youtube.com/watch?v=[...]` -> `https://youtube.com/watch?v=[...]`</item>
+    ///             <item>`https://open.spotify.com/playlist/[...]` -> `https://open.spotify.com/playlist/[...]`</item>
+    ///         </list>
+    ///     </example>
+    /// </remarks>
+    Passthrough,
+}

--- a/src/Lavalink4NET.Rest/Entities/Tracks/TrackLoadOptions.cs
+++ b/src/Lavalink4NET.Rest/Entities/Tracks/TrackLoadOptions.cs
@@ -3,4 +3,17 @@
 public readonly record struct TrackLoadOptions(
     TrackSearchMode SearchMode = default,
     StrictSearchBehavior SearchBehavior = StrictSearchBehavior.Throw,
-    CacheMode CacheMode = CacheMode.Dynamic);
+    CacheMode CacheMode = CacheMode.Dynamic)
+{
+    // Constructor for compatibility
+    public TrackLoadOptions(
+        TrackSearchMode SearchMode = default,
+        bool? StrictSearch = null,
+        CacheMode CacheMode = CacheMode.Dynamic) : this(
+            SearchMode: SearchMode,
+            SearchBehavior: StrictSearch.GetValueOrDefault(true) ? StrictSearchBehavior.Throw : StrictSearchBehavior.Passthrough,
+            CacheMode: CacheMode)
+    {
+
+    }
+}

--- a/src/Lavalink4NET.Rest/Entities/Tracks/TrackLoadOptions.cs
+++ b/src/Lavalink4NET.Rest/Entities/Tracks/TrackLoadOptions.cs
@@ -2,5 +2,5 @@
 
 public readonly record struct TrackLoadOptions(
     TrackSearchMode SearchMode = default,
-    bool? StrictSearch = null,
+    StrictSearchBehavior SearchBehavior = StrictSearchBehavior.Throw,
     CacheMode CacheMode = CacheMode.Dynamic);


### PR DESCRIPTION
This PR will solve various problems that were present with the old strict search solution. The default will stay to be the most pedantic option (`Throw`) which will fail if Lavalink4NET recognizes an attempt of the user trying to specify a search mode. However, this option also flagged search queries like `PR: abc` which may be valid search queries for some tracks. The option `Resolve` solves this problem by prepending the search prefix to those queries.

Please read the documentation of `StrictSearchBehavior` to learn more about the various new behaviors.

For users that previously enabled or disabled strict search, the option `Throw` matches the exact behavior as previously when strict search was enabled. The `Passthrough` options most likely matches the behavior as when strict search was disabled.