### PR TITLE
Update Lavalink4NET.DSharpPlus.Nightly to latest build

### DIFF
--- a/src/Lavalink4NET.DSharpPlus.Nightly/DiscordClientWrapper.cs
+++ b/src/Lavalink4NET.DSharpPlus.Nightly/DiscordClientWrapper.cs
@@ -17,7 +17,7 @@ using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 
 /// <summary>
-/// Wraps a <see cref="DiscordClient"/> or <see cref="DiscordShardedClient"/> instance.
+/// Wraps a <see cref="DiscordClient"/> instance.
 /// </summary>
 public sealed class DiscordClientWrapper : IDiscordClientWrapper
 {
@@ -27,7 +27,7 @@ public sealed class DiscordClientWrapper : IDiscordClientWrapper
     /// <inheritdoc/>
     public event AsyncEventHandler<L4N.VoiceStateUpdatedEventArgs>? VoiceStateUpdated;
 
-    private readonly DiscordClient _client; // either DiscordShardedClient or DiscordClient
+    private readonly DiscordClient _client; // sharded clients are now also managed by the same DiscordClient type
     private readonly ILogger<DiscordClientWrapper> _logger;
     private readonly TaskCompletionSource<ClientInformation> _readyTaskCompletionSource;
     private bool _disposed;

--- a/src/Lavalink4NET.DSharpPlus.Nightly/DiscordClientWrapper.cs
+++ b/src/Lavalink4NET.DSharpPlus.Nightly/DiscordClientWrapper.cs
@@ -30,7 +30,6 @@ public sealed class DiscordClientWrapper : IDiscordClientWrapper
     private readonly DiscordClient _client; // sharded clients are now also managed by the same DiscordClient type
     private readonly ILogger<DiscordClientWrapper> _logger;
     private readonly TaskCompletionSource<ClientInformation> _readyTaskCompletionSource;
-    private bool _disposed;
 
     /// <summary>
     /// Creates a new instance of <see cref="DiscordClientWrapper"/>.

--- a/src/Lavalink4NET.DSharpPlus.Nightly/Lavalink4NET.DSharpPlus.Nightly.csproj
+++ b/src/Lavalink4NET.DSharpPlus.Nightly/Lavalink4NET.DSharpPlus.Nightly.csproj
@@ -11,7 +11,7 @@
     <PackAsTool>False</PackAsTool>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02304" />
+    <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02306" />
     <ProjectReference Include="../Lavalink4NET/Lavalink4NET.csproj" />
   </ItemGroup>
   <Import Project="../Lavalink4NET.targets" />


### PR DESCRIPTION
The `DiscordShardedClient` has been removed in the latest nightly build in favor of using a shard orchestrator on the normal `DiscordClient`. This PR updates the wrapper to act in accordance with these changes.