### PR TITLE
Implement proper shard count retrieval

### DIFF
--- a/src/Lavalink4NET.DSharpPlus.Nightly/DSharpPlusUtilities.cs
+++ b/src/Lavalink4NET.DSharpPlus.Nightly/DSharpPlusUtilities.cs
@@ -4,7 +4,9 @@ using System;
 using System.Collections.Concurrent;
 using System.Reflection;
 using global::DSharpPlus;
+using global::DSharpPlus.Clients;
 using global::DSharpPlus.AsyncEvents;
+using System.Threading.Tasks;
 
 /// <summary>
 ///     An utility for getting internal / private fields from DSharpPlus WebSocket Gateway Payloads.
@@ -54,4 +56,38 @@ public static partial class DSharpPlusUtilities
     /// <param name="asyncEvent">the instance</param>
     /// <param name="delegate">the event to register</param>
     public static void Register(this AsyncEvent asyncEvent, Delegate @delegate) => asyncEventRegisterMethod.Invoke(asyncEvent, [@delegate]);
+
+    /// <summary>
+    ///     The internal "orchestrator" property info in <see cref="DiscordClient"/>.
+    /// </summary>
+    // https://github.com/DSharpPlus/DSharpPlus/blob/master/DSharpPlus/Clients/DiscordClient.cs#L47
+    private static readonly FieldInfo orchestratorField =
+        typeof(DiscordClient).GetField("orchestrator", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    /// <summary>
+    ///     The internal "shardCount" property info in <see cref="MultiShardOrchestrator"/>.
+    /// </summary>
+    // https://github.com/DSharpPlus/DSharpPlus/blob/master/DSharpPlus/Clients/DiscordClient.cs#L47
+    private static readonly FieldInfo shardCountField =
+        typeof(MultiShardOrchestrator).GetField("shardCount", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    /// <summary>
+    /// Gets the number of connected shards or this client
+    /// </summary>
+    public static async ValueTask<int> GetShardCountAsync(this DiscordClient client)
+    {
+        var orchestrator = (IShardOrchestrator)orchestratorField.GetValue(client)!;
+
+        if (orchestrator is SingleShardOrchestrator)
+            return 1;
+
+        if (orchestrator is MultiShardOrchestrator multiShardOrchestrator)
+            return (int)(uint)shardCountField.GetValue(multiShardOrchestrator)!;
+
+        // If the orchestrator is neither a Single nor Multi sharded orchestrator, that means it
+        // is using a custom solution implemented by the end user. There is no way to directly access
+        // the shard count in this case, so instead we estimate it by using Discord's recommended
+        // shard amount.
+        return (await client.GetGatewayInfoAsync()).ShardCount;
+    }
 }

--- a/src/Lavalink4NET.DSharpPlus.Nightly/DiscordClientWrapper.cs
+++ b/src/Lavalink4NET.DSharpPlus.Nightly/DiscordClientWrapper.cs
@@ -160,7 +160,7 @@ public sealed class DiscordClientWrapper : IDiscordClientWrapper
         var clientInformation = new ClientInformation(
             Label: "DSharpPlus",
             CurrentUserId: discordClient.CurrentUser.Id,
-            ShardCount: (await discordClient.GetGatewayInfoAsync()).ShardCount);
+            ShardCount: await discordClient.GetShardCountAsync());
 
         _readyTaskCompletionSource.TrySetResult(clientInformation);
     }

--- a/src/Lavalink4NET.DSharpPlus.Nightly/Lavalink4NET.DSharpPlus.Nightly.csproj
+++ b/src/Lavalink4NET.DSharpPlus.Nightly/Lavalink4NET.DSharpPlus.Nightly.csproj
@@ -11,7 +11,7 @@
     <PackAsTool>False</PackAsTool>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02306" />
+    <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02324" />
     <ProjectReference Include="../Lavalink4NET/Lavalink4NET.csproj" />
   </ItemGroup>
   <Import Project="../Lavalink4NET.targets" />


### PR DESCRIPTION
This PR correctly accesses the real number of connected shards, rather than using Discord's recommended count.

In the event that a shard count is un-retrievable, such as when the user implements their own shard orchestrator, the Discord recommendation is used as a fallback.