### PR TITLE
Fix assigning _nextOverridenPlayableItemIdentifier value when starting track in LavalinkPlayer

### DIFF
--- a/src/Lavalink4NET/Players/LavalinkPlayer.cs
+++ b/src/Lavalink4NET/Players/LavalinkPlayer.cs
@@ -267,7 +267,8 @@ public class LavalinkPlayer : ILavalinkPlayer, ILavalinkPlayerListener
                 .GetPlayableTrackAsync(cancellationToken)
                 .ConfigureAwait(false);
 
-            updateProperties.TrackData = _nextOverridenPlayableItemIdentifier = playableTrack.ToString();
+            _nextOverridenPlayableItemIdentifier = playableTrack.Identifier;
+            updateProperties.TrackData = playableTrack.ToString();
         }
         else
         {


### PR DESCRIPTION
We need to assign identifier instead of full encoded track data.