### PR TITLE
Move firing player NotifyTrackEndedAsync after setting current item to null and updating status

### DIFF
--- a/src/Lavalink4NET/Players/LavalinkPlayer.cs
+++ b/src/Lavalink4NET/Players/LavalinkPlayer.cs
@@ -195,15 +195,15 @@ public class LavalinkPlayer : ILavalinkPlayer, ILavalinkPlayerListener
 
         try
         {
-            await NotifyTrackEndedAsync(previousItem, endReason, cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
             if (Volatile.Read(ref _trackVersion) == currentTrackVersion && endReason is not TrackEndReason.Replaced)
             {
                 CurrentItem = null;
                 await UpdateStateAsync(PlayerState.NotPlaying, cancellationToken).ConfigureAwait(false);
             }
+        }
+        finally
+        {
+            await NotifyTrackEndedAsync(previousItem, endReason, cancellationToken).ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
Otherwise we can't actually react to _actual_ state changing, since player event was fired before the status changed.