### PR TITLE
LavalinkPlayerHandle improvements

### DIFF
--- a/src/Lavalink4NET/Players/LavalinkPlayerHandle.cs
+++ b/src/Lavalink4NET/Players/LavalinkPlayerHandle.cs
@@ -211,6 +211,11 @@ internal sealed class LavalinkPlayerHandle<TPlayer, TOptions> : ILavalinkPlayerH
             }
         }
 
+        if (_options.Value.InitialPosition is not null)
+        {
+            playerProperties = playerProperties with { Position = _options.Value.InitialPosition.Value };
+        }
+
         if (_options.Value.InitialVolume is not null)
         {
             playerProperties = playerProperties with { Volume = _options.Value.InitialVolume.Value, };

--- a/src/Lavalink4NET/Players/LavalinkPlayerHandle.cs
+++ b/src/Lavalink4NET/Players/LavalinkPlayerHandle.cs
@@ -198,7 +198,8 @@ internal sealed class LavalinkPlayerHandle<TPlayer, TOptions> : ILavalinkPlayerH
 
             if (initialTrack.Reference.IsPresent)
             {
-                playerProperties = playerProperties with { TrackData = initialTrack.Track!.ToString(), };
+                var playableTrack = await initialTrack.Reference.Track.GetPlayableTrackAsync(cancellationToken);
+                playerProperties = playerProperties with { TrackData = playableTrack.ToString()};
             }
             else
             {

--- a/src/Lavalink4NET/Players/LavalinkPlayerOptions.cs
+++ b/src/Lavalink4NET/Players/LavalinkPlayerOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Lavalink4NET.Players;
+﻿using System;
+
+namespace Lavalink4NET.Players;
 
 using Lavalink4NET.Rest.Entities.Tracks;
 
@@ -11,6 +13,8 @@ public record class LavalinkPlayerOptions
     public string? Label { get; set; }
 
     public ITrackQueueItem? InitialTrack { get; set; }
+
+    public TimeSpan? InitialPosition { get; set; }
 
     public TrackLoadOptions InitialLoadOptions { get; set; }
 

--- a/src/Lavalink4NET/Players/PlayerManager.cs
+++ b/src/Lavalink4NET/Players/PlayerManager.cs
@@ -312,11 +312,10 @@ internal sealed class PlayerManager : IPlayerManager, IDisposable, IPlayerLifecy
 
         await using var _ = playerHandle.ConfigureAwait(false);
 
-        Debug.Assert(playerHandle.Player is not null);
-        Debug.Assert(playerHandle.Player is { State: PlayerState.Destroyed, });
-
+        // Player can be null if lavalink node will throw while creating player
         if (playerHandle.Player is not null)
         {
+            Debug.Assert(playerHandle.Player is { State: PlayerState.Destroyed, });
             var eventArgs = new PlayerDestroyedEventArgs(playerHandle.Player);
 
             await PlayerDestroyed


### PR DESCRIPTION
- Add support for track overriding for initial track
- Add initial position to track create options
- Add exception handling for the CreatePlayerAsync in LavalinkPlayerHandle, since lavalink node can throw error while creating the player, resulted in soft-lock for current guild until bot restart, cuz we have LavalinkPlayerHandle which will never complete