### PR TITLE
Allow overriding ILavalinkSessionProvider while resolving/joining player

### DIFF
--- a/src/Lavalink4NET/Players/IPlayerManager.cs
+++ b/src/Lavalink4NET/Players/IPlayerManager.cs
@@ -37,6 +37,15 @@ public interface IPlayerManager
         where TPlayer : ILavalinkPlayer
         where TOptions : LavalinkPlayerOptions;
 
+    ValueTask<TPlayer> JoinAsync<TPlayer, TOptions>(ulong guildId, ulong voiceChannelId,
+        PlayerFactory<TPlayer, TOptions> playerFactory, IOptions<TOptions> options,
+        ILavalinkSessionProvider? overridenLavalinkSessionProvider, CancellationToken cancellationToken = default)
+        where TPlayer : ILavalinkPlayer
+        where TOptions : LavalinkPlayerOptions
+    {
+        return JoinAsync(guildId, voiceChannelId, playerFactory, options, cancellationToken);
+    }
+
     ValueTask<PlayerResult<TPlayer>> RetrieveAsync<TPlayer, TOptions>(
         ulong guildId,
         ulong? memberVoiceChannel,
@@ -45,9 +54,5 @@ public interface IPlayerManager
         PlayerRetrieveOptions retrieveOptions = default,
         CancellationToken cancellationToken = default)
         where TPlayer : class, ILavalinkPlayer
-        where TOptions : LavalinkPlayerOptions;
-
-    ValueTask<TPlayer> JoinAsync<TPlayer, TOptions>(ulong guildId, ulong voiceChannelId, PlayerFactory<TPlayer, TOptions> playerFactory, IOptions<TOptions> options, ILavalinkSessionProvider? overridenLavalinkSessionProvider, CancellationToken cancellationToken = default)
-        where TPlayer : ILavalinkPlayer
         where TOptions : LavalinkPlayerOptions;
 }

--- a/src/Lavalink4NET/Players/IPlayerManager.cs
+++ b/src/Lavalink4NET/Players/IPlayerManager.cs
@@ -46,4 +46,8 @@ public interface IPlayerManager
         CancellationToken cancellationToken = default)
         where TPlayer : class, ILavalinkPlayer
         where TOptions : LavalinkPlayerOptions;
+
+    ValueTask<TPlayer> JoinAsync<TPlayer, TOptions>(ulong guildId, ulong voiceChannelId, PlayerFactory<TPlayer, TOptions> playerFactory, IOptions<TOptions> options, ILavalinkSessionProvider? overridenLavalinkSessionProvider, CancellationToken cancellationToken = default)
+        where TPlayer : ILavalinkPlayer
+        where TOptions : LavalinkPlayerOptions;
 }

--- a/src/Lavalink4NET/Players/PlayerRetrieveOptions.cs
+++ b/src/Lavalink4NET/Players/PlayerRetrieveOptions.cs
@@ -7,4 +7,5 @@ using Lavalink4NET.Players.Preconditions;
 public readonly record struct PlayerRetrieveOptions(
     PlayerChannelBehavior ChannelBehavior = PlayerChannelBehavior.None,
     MemberVoiceStateBehavior VoiceStateBehavior = MemberVoiceStateBehavior.Ignore,
-    ImmutableArray<IPlayerPrecondition> Preconditions = default);
+    ImmutableArray<IPlayerPrecondition> Preconditions = default,
+    ILavalinkSessionProvider? OverridenSessionProvider = null);

--- a/tests/Lavalink4NET.InactivityTracking.Tests/PlayerManagerMock.cs
+++ b/tests/Lavalink4NET.InactivityTracking.Tests/PlayerManagerMock.cs
@@ -54,6 +54,13 @@ internal class PlayerManagerMock : IPlayerManager
     {
         throw new NotImplementedException();
     }
+    
+    public ValueTask<TPlayer> JoinAsync<TPlayer, TOptions>(ulong guildId, ulong voiceChannelId, PlayerFactory<TPlayer, TOptions> playerFactory,
+        IOptions<TOptions> options, ILavalinkSessionProvider? overridenLavalinkSessionProvider,
+        CancellationToken cancellationToken = default) where TPlayer : ILavalinkPlayer where TOptions : LavalinkPlayerOptions
+    {
+        throw new NotImplementedException();
+    }
 
     public bool TryGetPlayer(ulong guildId, [MaybeNullWhen(false)] out ILavalinkPlayer player)
     {


### PR DESCRIPTION
It allows creating player on the certain node/set of nodes when required.

It should not introduce breaking changes, since the new overload of `JoinAsync` in `IPlayerManager` has a default implementation which will call the old one by default for those who implements the `IPlayerManager` byself.