### PR TITLE
Fix #185

### DIFF
--- a/src/Lavalink4NET/Extensions/QueuedLavalinkPlayerExtensions.cs
+++ b/src/Lavalink4NET/Extensions/QueuedLavalinkPlayerExtensions.cs
@@ -12,12 +12,12 @@ public static class QueuedLavalinkPlayerExtensions
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var queueOffset = default(int?);
+        int? queueOffset = default;
 
         if (loadResult.Playlist is null)
         {
             // Single track
-            queueOffset ??= await player
+            queueOffset = await player
               .PlayAsync(loadResult.Track!, cancellationToken: cancellationToken)
               .ConfigureAwait(false);
         }
@@ -26,7 +26,7 @@ public static class QueuedLavalinkPlayerExtensions
             // Playlist
             foreach (var track in loadResult.Tracks)
             {
-                queueOffset ??= await player
+                queueOffset = await player
                   .PlayAsync(track, cancellationToken: cancellationToken)
                   .ConfigureAwait(false);
             }

--- a/src/Lavalink4NET/Extensions/QueuedLavalinkPlayerExtensions.cs
+++ b/src/Lavalink4NET/Extensions/QueuedLavalinkPlayerExtensions.cs
@@ -8,6 +8,15 @@ using Lavalink4NET.Rest.Entities.Tracks;
 
 public static class QueuedLavalinkPlayerExtensions
 {
+    /// <summary>
+    /// Adds a <see cref="TrackLoadResult"/> to the player's queue.<br/>
+    /// Returns the index of the track in the queue (or the last track added to the queue if <paramref name="loadResult"/> is a playlist)
+    /// </summary>
+    /// <param name="player">The player to enqueue the load result to.</param>
+    /// <param name="loadResult">The load result you want to enqueue.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The index of the track in the queue (or the last track added to the queue if <paramref name="loadResult"/> is a playlist)</returns>
+    /// <exception cref="InvalidOperationException">When the <paramref name="loadResult"/> contains no tracks.</exception>
     public static async ValueTask<int> PlayAsync(this IQueuedLavalinkPlayer player, TrackLoadResult loadResult, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
Fixes the issue described in #185

We don't need to use the null check operator, as the result will always be null before assigning.
Document that the returned index is the index of the _last_ track added to the queue if a playlist is passed, not the first.

Ex: queueing 5 tracks on a player that is currently playing, but has an empty queue, _should_ return 5.