### PR TITLE
Fix "Adding a playlist via 'QueuedLavalinkPlayerExtensions' does not work"

### DIFF
--- a/src/Lavalink4NET/Extensions/QueuedLavalinkPlayerExtensions.cs
+++ b/src/Lavalink4NET/Extensions/QueuedLavalinkPlayerExtensions.cs
@@ -12,12 +12,12 @@ public static class QueuedLavalinkPlayerExtensions
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var queueOffset = default(int?);
+        int? queueOffset = default;
 
         if (loadResult.Playlist is null)
         {
             // Single track
-            queueOffset ??= await player
+            queueOffset = await player
               .PlayAsync(loadResult.Track!, cancellationToken: cancellationToken)
               .ConfigureAwait(false);
         }
@@ -26,7 +26,7 @@ public static class QueuedLavalinkPlayerExtensions
             // Playlist
             foreach (var track in loadResult.Tracks)
             {
-                queueOffset ??= await player
+                queueOffset = await player
                   .PlayAsync(track, cancellationToken: cancellationToken)
                   .ConfigureAwait(false);
             }

--- a/src/Lavalink4NET/Extensions/QueuedLavalinkPlayerExtensions.cs
+++ b/src/Lavalink4NET/Extensions/QueuedLavalinkPlayerExtensions.cs
@@ -8,6 +8,15 @@ using Lavalink4NET.Rest.Entities.Tracks;
 
 public static class QueuedLavalinkPlayerExtensions
 {
+    /// <summary>
+    /// Adds a <see cref="TrackLoadResult"/> to the player's queue.<br/>
+    /// Returns the index of the track in the queue (or the last track added to the queue if <paramref name="loadResult"/> is a playlist)
+    /// </summary>
+    /// <param name="player">The player to enqueue the load result to.</param>
+    /// <param name="loadResult">The load result you want to enqueue.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The index of the track in the queue (or the last track added to the queue if <paramref name="loadResult"/> is a playlist)</returns>
+    /// <exception cref="InvalidOperationException">When the <paramref name="loadResult"/> contains no tracks.</exception>
     public static async ValueTask<int> PlayAsync(this IQueuedLavalinkPlayer player, TrackLoadResult loadResult, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
Fixes #185

Removes the compound null replacement assignment in favor of regular assigning. The default result value will always be null anyways, so we don't need it.

Adds documentation, and specifies that in the event a playlist is passed to this method, the result returned will be the index of the _last_ track added to the queue, not the first. This is more useful for things like determining queue length with less asynchronous executions in certain contexts, and generally is more useful to end users. When shuffling tracks that are added to the queue, this return result is irrelevant anyways.

Ex: if a player is currently playing, but has an empty track queue, and a playlist with 5 tracks is played, track index 5 _should_ be returned.

It may be worth adding support for determining whether you want the first or last index returned in the future, but it could also potentially be seen as clogging the API with unnecessary methods. Will have to see as time goes on.