### PR TITLE
Fix DSharpPlus.Nightly Compatibility

### DIFF
--- a/samples/Lavalink4NET.DSharpPlus.Nightly.ExampleBot/Lavalink4NET.DSharpPlus.Nightly.ExampleBot.csproj
+++ b/samples/Lavalink4NET.DSharpPlus.Nightly.ExampleBot/Lavalink4NET.DSharpPlus.Nightly.ExampleBot.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02355" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Lavalink4NET.DSharpPlus.Nightly.ExampleBot/Lavalink4NET.DSharpPlus.Nightly.ExampleBot.csproj
+++ b/samples/Lavalink4NET.DSharpPlus.Nightly.ExampleBot/Lavalink4NET.DSharpPlus.Nightly.ExampleBot.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02355" />
+    <PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02517" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />

--- a/samples/Lavalink4NET.DSharpPlus.Nightly.ExampleBot/MusicCommands.cs
+++ b/samples/Lavalink4NET.DSharpPlus.Nightly.ExampleBot/MusicCommands.cs
@@ -93,7 +93,7 @@ public class MusicCommands
         var playerOptions = new QueuedLavalinkPlayerOptions { HistoryCapacity = 10000 };
 
         var result = await _audioService.Players
-            .RetrieveAsync(commandContext.Guild!.Id, commandContext.Member?.VoiceState.ChannelId ?? null, playerFactory: PlayerFactory.Queued, Options.Create(playerOptions), retrieveOptions)
+            .RetrieveAsync(commandContext.Guild!.Id, commandContext.Member?.VoiceState.ChannelId, playerFactory: PlayerFactory.Queued, Options.Create(playerOptions), retrieveOptions)
             .ConfigureAwait(false);
 
         if (!result.IsSuccess)

--- a/samples/Lavalink4NET.DSharpPlus.Nightly.ExampleBot/MusicCommands.cs
+++ b/samples/Lavalink4NET.DSharpPlus.Nightly.ExampleBot/MusicCommands.cs
@@ -93,7 +93,7 @@ public class MusicCommands
         var playerOptions = new QueuedLavalinkPlayerOptions { HistoryCapacity = 10000 };
 
         var result = await _audioService.Players
-            .RetrieveAsync(commandContext.Guild!.Id, commandContext.Member?.VoiceState?.Channel?.Id ?? null, playerFactory: PlayerFactory.Queued, Options.Create(playerOptions), retrieveOptions)
+            .RetrieveAsync(commandContext.Guild!.Id, commandContext.Member?.VoiceState.ChannelId ?? null, playerFactory: PlayerFactory.Queued, Options.Create(playerOptions), retrieveOptions)
             .ConfigureAwait(false);
 
         if (!result.IsSuccess)

--- a/samples/Lavalink4NET.DSharpPlus.Nightly.ExampleBot/Program.cs
+++ b/samples/Lavalink4NET.DSharpPlus.Nightly.ExampleBot/Program.cs
@@ -15,7 +15,7 @@ builder.Services.AddHostedService<ApplicationHost>();
 
 // DSharpPlus
 builder.Services.AddDiscordClient("Your token here", DiscordIntents.AllUnprivileged);
-builder.Services.AddCommandsExtension(extension => extension.AddCommands(typeof(MusicCommands).Assembly));
+builder.Services.AddCommandsExtension((IServiceProvider sp, CommandsExtension c) => c.AddCommands(typeof(MusicCommands).Assembly));
 
 
 // Lavalink4NET

--- a/src/Lavalink4NET.DSharpPlus.Nightly/DiscordClientWrapper.cs
+++ b/src/Lavalink4NET.DSharpPlus.Nightly/DiscordClientWrapper.cs
@@ -179,18 +179,18 @@ public sealed class DiscordClientWrapper : IDiscordClientWrapper
 
         // create voice state
         var voiceState = new VoiceState(
-            VoiceChannelId: voiceStateUpdateEventArgs.After?.Channel?.Id,
+            VoiceChannelId: voiceStateUpdateEventArgs.After?.ChannelId,
             SessionId: sessionId);
 
         var oldVoiceState = new VoiceState(
-            VoiceChannelId: voiceStateUpdateEventArgs.Before?.Channel?.Id,
+            VoiceChannelId: voiceStateUpdateEventArgs.Before?.ChannelId,
             SessionId: sessionId);
 
         // invoke event
         var eventArgs = new Lavalink4NET.VoiceStateUpdatedEventArgs(
-            guildId: voiceStateUpdateEventArgs.Guild.Id,
-            userId: voiceStateUpdateEventArgs.User.Id,
-            isCurrentUser: voiceStateUpdateEventArgs.User.Id == discordClient.CurrentUser.Id,
+            guildId: voiceStateUpdateEventArgs.GuildId ?? 0,
+            userId: voiceStateUpdateEventArgs.UserId,
+            isCurrentUser: voiceStateUpdateEventArgs.UserId == discordClient.CurrentUser.Id,
             oldVoiceState: oldVoiceState,
             voiceState: voiceState);
 

--- a/src/Lavalink4NET.DSharpPlus.Nightly/DiscordClientWrapper.cs
+++ b/src/Lavalink4NET.DSharpPlus.Nightly/DiscordClientWrapper.cs
@@ -188,7 +188,7 @@ public sealed class DiscordClientWrapper : IDiscordClientWrapper
 
         // invoke event
         var eventArgs = new Lavalink4NET.VoiceStateUpdatedEventArgs(
-            guildId: voiceStateUpdateEventArgs.GuildId ?? 0,
+            guildId: voiceStateUpdateEventArgs.GuildId!.Value,
             userId: voiceStateUpdateEventArgs.UserId,
             isCurrentUser: voiceStateUpdateEventArgs.UserId == discordClient.CurrentUser.Id,
             oldVoiceState: oldVoiceState,

--- a/src/Lavalink4NET.DSharpPlus.Nightly/Lavalink4NET.DSharpPlus.Nightly.csproj
+++ b/src/Lavalink4NET.DSharpPlus.Nightly/Lavalink4NET.DSharpPlus.Nightly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <!-- Package Description -->
     <Description>High performance Lavalink wrapper for .NET | Add powerful audio playback to your DSharpPlus-nightly-based applications with this integration for Lavalink4NET. Suitable for end users developing with DSharpPlus Nightly builds.</Description>

--- a/src/Lavalink4NET.DSharpPlus.Nightly/Lavalink4NET.DSharpPlus.Nightly.csproj
+++ b/src/Lavalink4NET.DSharpPlus.Nightly/Lavalink4NET.DSharpPlus.Nightly.csproj
@@ -12,7 +12,7 @@
     <Version>1.0.4</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02354" />
+    <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02517" />
     <ProjectReference Include="../Lavalink4NET/Lavalink4NET.csproj" />
   </ItemGroup>
   <Import Project="../Lavalink4NET.targets" />


### PR DESCRIPTION
In the commit https://github.com/DSharpPlus/DSharpPlus/commit/46db7c85bfa8a301847e93a93ebdd694c70aff2b (version 02500) DSP refactored the Voice States which broke the Nightly implementation of Lavalink4NET.

As I updated DSP in my bot to the newest version it was able to connect to a voice channel but threw the following Exception:
```
DSharpPlus.IClientErrorHandler[0] Event handler exception for event DSharpPlus.EventArgs.VoiceStateUpdatedEventArgs thrown from System.Threading.Tasks.Task lambda_method27(System.Runtime.CompilerServices.Closure, DSharpPlus.DiscordClient, DSharpPlus.EventArgs.VoiceStateUpdatedEventArgs, System.IServiceProvider) (defined in (null)).
System.MissingMethodException: Method not found: 'DSharpPlus.Entities.DiscordChannel DSharpPlus.Entities.DiscordVoiceState.get_Channel()'.
   at Lavalink4NET.DSharpPlus.DiscordClientWrapper.OnVoiceStateUpdated(DiscordClient discordClient, VoiceStateUpdatedEventArgs voiceStateUpdateEventArgs)
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Lavalink4NET.DSharpPlus.DiscordClientWrapper.OnVoiceStateUpdated(DiscordClient discordClient, VoiceStateUpdatedEventArgs voiceStateUpdateEventArgs)
   at Lavalink4NET.DSharpPlus.Lavalink4NETInvokeHandlers.HandleEventAsync(DiscordClient sender, VoiceStateUpdatedEventArgs eventArgs) in /home/runner/work/Lavalink4NET/Lavalink4NET/src/Lavalink4NET.DSharpPlus.Nightly/Lavalink4NETInvokeHandlers.cs:line 25
   at DSharpPlus.Clients.DefaultEventDispatcher.<>c__DisplayClass6_0`1.<<DispatchAsync>b__0>d.MoveNext()
```

After digging through the library to the function mentioned in the StackTrace I did the following:
- Updated Lavalink4NET.DSharpPlus.Nightly and the ExampleBot to TFM .NET 9 (required by DSP)
- Updated DSharpPlus and DSharpPlus.Commands to version 02517 (the newest)
- Updated the ExampleBot Microsoft.Extensions.* package version to 9.0.6
- Applied a fix to make the ExampleBot work with the newest DSP versions
- Applied a fix to reference the refactored properties in the Nightly Client