### PR TITLE
Add Bandcamp search mode to TrackSearchMode

### DIFF
--- a/src/Lavalink4NET.Rest/Entities/Tracks/TrackSearchMode.cs
+++ b/src/Lavalink4NET.Rest/Entities/Tracks/TrackSearchMode.cs
@@ -5,6 +5,7 @@ public readonly record struct TrackSearchMode(string? Prefix)
     public static readonly TrackSearchMode YouTube = new("ytsearch");
     public static readonly TrackSearchMode YouTubeMusic = new("ytmsearch");
     public static readonly TrackSearchMode SoundCloud = new("scsearch");
+    public static readonly TrackSearchMode Bandcamp = new("bcsearch");
     public static readonly TrackSearchMode None = new(null);
 
     // Only available when using the Lavasearch integration


### PR DESCRIPTION
bcsearch is a valid [lavaplayer search prefix](https://github.com/lavalink-devs/lavaplayer/blob/f34f8382a79d501ceefef8a4092af23ba7b29039/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioSourceManager.java#L43) 