### PR TITLE
Update docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 ### Documentation
 
 > [!IMPORTANT]
-> You can find the documentation for Lavalink4NET v4 [here](https://lavalink4net.com/introduction/intro).
+> You can find the documentation for Lavalink4NET v4 [here](https://lavalink4net.com/docs/introduction/intro).
 
 ### Components
 


### PR DESCRIPTION
Current link seems to miss the /docs/ part.