### PR TITLE
Feature: ConnectionReady Event

### DIFF
--- a/src/Lavalink4NET/AudioServiceBase.cs
+++ b/src/Lavalink4NET/AudioServiceBase.cs
@@ -147,6 +147,8 @@ public abstract class AudioServiceBase : IAudioService, ILavalinkNodeListener
 
     public event AsyncEventHandler<ConnectionClosedEventArgs>? ConnectionClosed;
 
+    public event AsyncEventHandler<ConnectionReadyEventArgs>? ConnectionReady;
+
     protected virtual ValueTask OnTrackEndedAsync(TrackEndedEventArgs eventArgs, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -194,6 +196,13 @@ public abstract class AudioServiceBase : IAudioService, ILavalinkNodeListener
         cancellationToken.ThrowIfCancellationRequested();
         ArgumentNullException.ThrowIfNull(eventArgs);
         return WebSocketClosed.InvokeAsync(this, eventArgs);
+    }
+
+    protected virtual ValueTask OnConnectionReadyAsync(ConnectionReadyEventArgs eventArgs, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(eventArgs);
+        return ConnectionReady.InvokeAsync(this, eventArgs);
     }
 
     ValueTask ILavalinkNodeListener.OnTrackEndedAsync(TrackEndedEventArgs eventArgs, CancellationToken cancellationToken)
@@ -337,6 +346,12 @@ public abstract class AudioServiceBase : IAudioService, ILavalinkNodeListener
         ArgumentNullException.ThrowIfNull(eventArgs);
 
         return OnConnectionClosedAsync(eventArgs, cancellationToken);
+    }
+
+    ValueTask ILavalinkNodeListener.OnConnectionReadyAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return OnConnectionReadyAsync(new ConnectionReadyEventArgs(), cancellationToken);
     }
 }
 

--- a/src/Lavalink4NET/Events/ConnectionReadyEventArgs.cs
+++ b/src/Lavalink4NET/Events/ConnectionReadyEventArgs.cs
@@ -1,0 +1,16 @@
+namespace Lavalink4NET.Events;
+
+using System;
+
+/// <summary>
+///     The event arguments for the <see cref="IAudioService.ConnectionReady"/> event.
+/// </summary>
+public sealed class ConnectionReadyEventArgs : EventArgs
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ConnectionReadyEventArgs"/> class.
+    /// </summary>
+    public ConnectionReadyEventArgs()
+    {
+    }
+}

--- a/src/Lavalink4NET/IAudioService.cs
+++ b/src/Lavalink4NET/IAudioService.cs
@@ -30,6 +30,14 @@ public interface IAudioService : IAsyncDisposable
 
     event AsyncEventHandler<ConnectionClosedEventArgs>? ConnectionClosed;
 
+    /// <summary>
+    ///     Occurs when a connection to a Lavalink node is established and ready.
+    /// </summary>
+    /// <remarks>
+    ///     This event is raised both on initial connection and on reconnection to a Lavalink node.
+    /// </remarks>
+    event AsyncEventHandler<ConnectionReadyEventArgs>? ConnectionReady;
+
     IDiscordClientWrapper DiscordClient { get; }
 
     IIntegrationManager Integrations { get; }

--- a/src/Lavalink4NET/ILavalinkNodeListener.cs
+++ b/src/Lavalink4NET/ILavalinkNodeListener.cs
@@ -20,4 +20,6 @@ internal interface ILavalinkNodeListener
     ValueTask OnWebSocketClosedAsync(WebSocketClosedEventArgs eventArgs, CancellationToken cancellationToken = default);
 
     ValueTask OnConnectionClosedAsync(ConnectionClosedEventArgs eventArgs, CancellationToken cancellationToken = default);
+
+    ValueTask OnConnectionReadyAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Lavalink4NET/LavalinkNode.cs
+++ b/src/Lavalink4NET/LavalinkNode.cs
@@ -170,7 +170,8 @@ internal sealed class LavalinkNode : IAsyncDisposable
             }
 
             _logger.Ready(Label, SessionId);
-            await SocketConnectionReady.InvokeAsync(this, EventArgs.Empty);
+            await SocketConnectionReady.InvokeAsync(this, EventArgs.Empty).ConfigureAwait(false);
+            await _serviceContext.NodeListener.OnConnectionReadyAsync(cancellationToken).ConfigureAwait(false);
         }
 
         if (SessionId is null)

--- a/tests/Lavalink4NET.Tests/AudioServiceTests.cs
+++ b/tests/Lavalink4NET.Tests/AudioServiceTests.cs
@@ -371,6 +371,65 @@ public sealed class AudioServiceTests
     }
 
     [Fact]
+    public async Task TestConnectionReadyEventIsRaisedAsync()
+    {
+        // Arrange
+        var apiClientMock = new Mock<ILavalinkApiClient>();
+        var socketMock = new Mock<ILavalinkSocket>();
+        var discordClientMock = new Mock<IDiscordClientWrapper>();
+
+        apiClientMock
+            .SetupGet(x => x.Endpoints)
+            .Returns(new LavalinkApiEndpoints(new Uri("http://localhost/")));
+
+        var receiveChannel = Channel.CreateUnbounded<IPayload>();
+
+        var socketFactory = Mock.Of<ILavalinkSocketFactory>(
+            x => x.Create(It.IsAny<IOptions<LavalinkSocketOptions>>()) == socketMock.Object);
+
+        socketMock
+            .Setup(x => x.ReceiveAsync(It.IsAny<CancellationToken>()))
+            .Returns((CancellationToken cancellationToken)
+                => receiveChannel.Reader.ReadAsync(cancellationToken)!);
+
+        discordClientMock
+            .Setup(x => x.WaitForReadyAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ClientInformation("Mock Client", 0UL, 1));
+
+        await using var audioService = new AudioService(
+            discordClient: discordClientMock.Object,
+            apiClientProvider: CreateProvider(apiClientMock.Object),
+            playerManager: Mock.Of<IPlayerManager>(),
+            trackManager: Mock.Of<ITrackManager>(),
+            socketFactory: socketFactory!,
+            integrationManager: new IntegrationManager(),
+            loggerFactory: NullLoggerFactory.Instance,
+            options: Options.Create(new AudioServiceOptions { ReadyTimeout = TimeSpan.FromSeconds(0.5) }));
+
+        _ = audioService.StartAsync().AsTask();
+
+        // Act
+        async Task Action()
+        {
+            receiveChannel.Writer.TryWrite(new ReadyPayload(
+                SessionResumed: false,
+                SessionId: "test-session"));
+
+            await audioService!
+                .WaitForReadyAsync()
+                .ConfigureAwait(false);
+
+            await Task.Delay(100);
+        }
+
+        // Assert
+        await AssertRaisesAsync<ConnectionReadyEventArgs>(
+            attach: handler => audioService.ConnectionReady += handler,
+            detach: handler => audioService.ConnectionReady -= handler,
+            testCode: Action);
+    }
+
+    [Fact]
     public async Task TestTrackStuckDispatchesAsync()
     {
         var apiClientMock = new Mock<ILavalinkApiClient>();

--- a/tests/Lavalink4NET.Tests/LavalinkNodeTests.cs
+++ b/tests/Lavalink4NET.Tests/LavalinkNodeTests.cs
@@ -322,6 +322,83 @@ public sealed class LavalinkNodeTests
     }
 
     [Fact]
+    public async Task TestReadyPayloadDispatchesConnectionReadyEventAsync()
+    {
+        // Arrange
+        using var socketFactory = new LavalinkSocketFactory();
+
+        var nodeListener = new Mock<ILavalinkNodeListener>();
+
+        var serviceContext = new LavalinkNodeServiceContext(
+            ClientWrapper: Mock.Of<IDiscordClientWrapper>(),
+            LavalinkSocketFactory: socketFactory,
+            IntegrationManager: new IntegrationManager(),
+            PlayerManager: Mock.Of<IPlayerManager>(),
+            NodeListener: nodeListener.Object);
+
+        var node = new LavalinkNode(
+            serviceContext,
+            apiClient: Mock.Of<ILavalinkApiClient>(),
+            options: Options.Create(new NodeOptions { }),
+            apiEndpoints: new LavalinkApiEndpoints(new Uri("http://localhost/")),
+            logger: NullLogger<LavalinkNode>.Instance);
+
+        _ = node.RunAsync(new ClientInformation("Client", 0, 1)).AsTask();
+        await using var __ = node.ConfigureAwait(false);
+
+        // Act
+        socketFactory.Socket.Send(new ReadyPayload(false, "abc"));
+        socketFactory.Socket.Complete();
+
+        await Task.Delay(100);
+
+        // Assert
+        nodeListener.Verify(
+            expression: listener => listener.OnConnectionReadyAsync(It.IsAny<CancellationToken>()),
+            times: Times.Once());
+    }
+
+    [Fact]
+    public async Task TestReadyPayloadDispatchesConnectionReadyOnReconnectAsync()
+    {
+        // Arrange
+        using var socketFactory = new LavalinkSocketFactory();
+
+        var nodeListener = new Mock<ILavalinkNodeListener>();
+
+        var serviceContext = new LavalinkNodeServiceContext(
+            ClientWrapper: Mock.Of<IDiscordClientWrapper>(),
+            LavalinkSocketFactory: socketFactory,
+            IntegrationManager: new IntegrationManager(),
+            PlayerManager: Mock.Of<IPlayerManager>(),
+            NodeListener: nodeListener.Object);
+
+        var node = new LavalinkNode(
+            serviceContext,
+            apiClient: Mock.Of<ILavalinkApiClient>(),
+            options: Options.Create(new NodeOptions { }),
+            apiEndpoints: new LavalinkApiEndpoints(new Uri("http://localhost/")),
+            logger: NullLogger<LavalinkNode>.Instance);
+
+        _ = node.RunAsync(new ClientInformation("Client", 0, 1)).AsTask();
+        await using var __ = node.ConfigureAwait(false);
+
+        // Act - Send two ReadyPayloads to simulate initial connection + reconnection
+        socketFactory.Socket.Send(new ReadyPayload(false, "session-1"));
+        await Task.Delay(100);
+
+        socketFactory.Socket.Send(new ReadyPayload(false, "session-2"));
+        await Task.Delay(100);
+
+        socketFactory.Socket.Complete();
+
+        // Assert - Should be called twice (initial + reconnect)
+        nodeListener.Verify(
+            expression: listener => listener.OnConnectionReadyAsync(It.IsAny<CancellationToken>()),
+            times: Times.Exactly(2));
+    }
+
+    [Fact]
     public async Task TestTrackExceptionPayloadDispatchesTrackExceptionEventAsync()
     {
         // Arrange


### PR DESCRIPTION
This pull request introduces a new `ConnectionReady` event to the Lavalink4NET audio service, allowing consumers to be notified when a connection to a Lavalink node is established or re-established.

**References**
Issue #236 