### PR TITLE
Fix: Session timeout duration converter to use seconds instead of milliseconds

### DIFF
--- a/src/Lavalink4NET.Protocol/Converters/NullableSecondsDurationJsonConverter.cs
+++ b/src/Lavalink4NET.Protocol/Converters/NullableSecondsDurationJsonConverter.cs
@@ -1,0 +1,41 @@
+﻿namespace Lavalink4NET.Protocol.Converters;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+internal sealed class NullableSecondsDurationJsonConverter : JsonConverter<TimeSpan?>
+{
+    public override TimeSpan? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(typeToConvert);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var value = reader.GetInt64();
+        return value < 0 ? null : TimeSpan.FromSeconds(value);
+    }
+
+    public override void Write(Utf8JsonWriter writer, TimeSpan? value, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (value is null)
+        {
+            writer.WriteNumberValue(-1);
+        }
+        else
+        {
+            if (value.Value < TimeSpan.Zero)
+            {
+                ThrowNegative();
+            }
+
+            writer.WriteNumberValue((long)Math.Round(value.Value.TotalSeconds));
+        }
+
+        [DoesNotReturn]
+        void ThrowNegative() => throw new ArgumentOutOfRangeException(nameof(value), value, "The duration must not be negative.");
+    }
+}

--- a/src/Lavalink4NET.Protocol/Models/SessionModel.cs
+++ b/src/Lavalink4NET.Protocol/Models/SessionModel.cs
@@ -11,5 +11,5 @@ public sealed record class SessionModel(
 
     [property: JsonRequired]
     [property: JsonPropertyName("timeout")]
-    [property: JsonConverter(typeof(NullableDurationJsonConverter))]
+    [property: JsonConverter(typeof(NullableSecondsDurationJsonConverter))]
     TimeSpan? SessionTimeout);

--- a/src/Lavalink4NET.Protocol/Requests/SessionUpdateRequest.cs
+++ b/src/Lavalink4NET.Protocol/Requests/SessionUpdateRequest.cs
@@ -12,6 +12,6 @@ public sealed record class SessionUpdateProperties
 
     [JsonPropertyName("timeout")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [JsonConverter(typeof(OptionalJsonConverter<TimeSpan?, NullableDurationJsonConverter>))]
+    [JsonConverter(typeof(OptionalJsonConverter<TimeSpan?, NullableSecondsDurationJsonConverter>))]
     public Optional<TimeSpan?> Timeout { get; set; }
 }


### PR DESCRIPTION
## Summary
The session `timeout` field in the Lavalink protocol is represented in
**seconds**, not milliseconds. The previously used `NullableDurationJsonConverter`
was operating in milliseconds, causing a 1000x incorrect timeout value
being sent to and received from the Lavalink server.

## Root Cause
https://lavalink.dev/api/rest#update-session

| Field | Type | Description |
|-------|------|-------------|
| timeout | int | The timeout in **seconds** (default is 60s) |

`NullableDurationJsonConverter` used `TimeSpan.FromMilliseconds` / `TotalMilliseconds`
which did not align with the protocol's unit.