### PR TITLE
fix: auto-rejoin voice on 4014/4015 websocket close

### DIFF
--- a/src/Lavalink4NET/Players/LavalinkPlayer.cs
+++ b/src/Lavalink4NET/Players/LavalinkPlayer.cs
@@ -29,6 +29,11 @@ public class LavalinkPlayer : ILavalinkPlayer, ILavalinkPlayerListener
     private readonly ISystemClock _systemClock;
     private readonly bool _disconnectOnStop;
     private readonly IPlayerLifecycle _playerLifecycle;
+    private readonly bool _enableVoiceAutoReconnect;
+    private readonly TimeSpan _voiceReconnectCooldown;
+    private readonly bool _selfDeaf;
+    private readonly bool _selfMute;
+    private long _lastVoiceReconnectAttemptTicks;
     private int _disposed;
     private DateTimeOffset _syncedAt;
     private TimeSpan _unstretchedRelativePosition;
@@ -65,6 +70,12 @@ public class LavalinkPlayer : ILavalinkPlayer, ILavalinkPlayerListener
 
         _disconnectOnDestroy = properties.Options.Value.DisconnectOnDestroy;
         _disconnectOnStop = properties.Options.Value.DisconnectOnStop;
+
+        _enableVoiceAutoReconnect = properties.Options.Value.EnableVoiceAutoReconnect;
+        _voiceReconnectCooldown = properties.Options.Value.VoiceReconnectCooldown;
+        _selfDeaf = properties.Options.Value.SelfDeaf;
+        _selfMute = properties.Options.Value.SelfMute;
+        _lastVoiceReconnectAttemptTicks = 0;
 
         VoiceServer = new VoiceServer(properties.InitialState.VoiceState.Token, properties.InitialState.VoiceState.Endpoint);
         VoiceState = new VoiceState(properties.VoiceChannelId, properties.InitialState.VoiceState.SessionId);
@@ -432,7 +443,62 @@ public class LavalinkPlayer : ILavalinkPlayer, ILavalinkPlayerListener
 #endif
     }
 
-    protected virtual ValueTask NotifyWebSocketClosedAsync(WebSocketCloseStatus closeStatus, string reason, bool byRemote = false, CancellationToken cancellationToken = default) => default;
+    protected virtual async ValueTask NotifyWebSocketClosedAsync(WebSocketCloseStatus closeStatus, string reason, bool byRemote = false, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Lavalink reports Discord voice websocket close codes as the websocket close status.
+        // Recoverable cases commonly include:
+        // - 4014: Disconnected
+        // - 4015: Voice server crashed
+        if (!byRemote || !_enableVoiceAutoReconnect)
+        {
+            return;
+        }
+
+        // Player is already destroyed/disposed.
+        if (_disposed is not 0)
+        {
+            return;
+        }
+
+        var closeCode = (int)closeStatus;
+        if (closeCode is not 4014 and not 4015)
+        {
+            return;
+        }
+
+        // If we intentionally left the channel (voice state is null), don't attempt to rejoin.
+        if (VoiceState.VoiceChannelId is null)
+        {
+            return;
+        }
+
+        // Avoid rejoin loops: only attempt once per cooldown window.
+        var nowTicks = _systemClock.UtcNow.UtcTicks;
+        var cooldownTicks = _voiceReconnectCooldown.Ticks;
+
+        // Atomically claim this attempt. This uses CAS to avoid concurrent callers
+        // both passing the cooldown check and sending multiple voice updates.
+        while (true)
+        {
+            var lastTicks = Interlocked.Read(ref _lastVoiceReconnectAttemptTicks);
+
+            if (cooldownTicks > 0 && lastTicks != 0 && nowTicks - lastTicks < cooldownTicks)
+            {
+                return;
+            }
+
+            if (Interlocked.CompareExchange(ref _lastVoiceReconnectAttemptTicks, nowTicks, lastTicks) == lastTicks)
+            {
+                break;
+            }
+        }
+
+        await DiscordClient
+            .SendVoiceUpdateAsync(GuildId, VoiceChannelId, selfDeaf: _selfDeaf, selfMute: _selfMute, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
 
     protected virtual ValueTask NotifyTrackEndedAsync(ITrackQueueItem track, TrackEndReason endReason, CancellationToken cancellationToken = default) => default;
 

--- a/src/Lavalink4NET/Players/LavalinkPlayerOptions.cs
+++ b/src/Lavalink4NET/Players/LavalinkPlayerOptions.cs
@@ -10,6 +10,17 @@ public record class LavalinkPlayerOptions
 
     public bool DisconnectOnDestroy { get; set; } = true;
 
+    /// <summary>
+    ///     Gets or sets a value indicating whether Lavalink4NET should attempt to recover voice connectivity
+    ///     by re-sending a voice state update when Discord closes the voice websocket (e.g. 4014/4015).
+    /// </summary>
+    public bool EnableVoiceAutoReconnect { get; set; } = true;
+
+    /// <summary>
+    ///     Gets or sets the minimum time between automatic voice reconnect attempts.
+    /// </summary>
+    public TimeSpan VoiceReconnectCooldown { get; set; } = TimeSpan.FromSeconds(10);
+
     public string? Label { get; set; }
 
     public ITrackQueueItem? InitialTrack { get; set; }

--- a/tests/Lavalink4NET.Tests/Players/LavalinkPlayerTests.cs
+++ b/tests/Lavalink4NET.Tests/Players/LavalinkPlayerTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
+using System.Net.WebSockets;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -119,6 +120,221 @@ public sealed class LavalinkPlayerTests
 
         // Assert
         Assert.Equal(PlayerState.Destroyed, player.State);
+    }
+
+    [Fact]
+    public async Task TestVoiceAutoReconnectAttemptsRejoinOn4014Async()
+    {
+        // Arrange
+        var discordClientMock = new Mock<IDiscordClientWrapper>(MockBehavior.Strict);
+
+        discordClientMock
+            .Setup(x => x.SendVoiceUpdateAsync(
+                guildId: 0UL,
+                voiceChannelId: 42UL,
+                selfDeaf: true,
+                selfMute: true,
+                It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        var playerModel = new PlayerInformationModel(
+            GuildId: 0UL,
+            CurrentTrack: null,
+            Volume: 1F,
+            IsPaused: false,
+            VoiceState: CreateVoiceState(),
+            Filters: new PlayerFilterMapModel());
+
+        var options = new LavalinkPlayerOptions
+        {
+            EnableVoiceAutoReconnect = true,
+            VoiceReconnectCooldown = TimeSpan.FromSeconds(10),
+            SelfDeaf = true,
+            SelfMute = true,
+        };
+
+        var playerProperties = CreateProperties(playerModel: playerModel, options: options, discordClientMock: discordClientMock);
+        var player = new LavalinkPlayer(playerProperties);
+
+        // Ensure we have a voice channel to re-assert.
+        var listener = (ILavalinkPlayerListener)player;
+        await listener.NotifyVoiceStateUpdatedAsync(new VoiceState(VoiceChannelId: 42UL, SessionId: "abc"));
+
+        // Act
+        await listener.NotifyWebSocketClosedAsync((WebSocketCloseStatus)4014, "Disconnected.", byRemote: true);
+
+        // Assert
+        discordClientMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task TestVoiceAutoReconnectAttemptsRejoinOn4015Async()
+    {
+        // Arrange
+        var discordClientMock = new Mock<IDiscordClientWrapper>(MockBehavior.Strict);
+
+        discordClientMock
+            .Setup(x => x.SendVoiceUpdateAsync(
+                guildId: 0UL,
+                voiceChannelId: 42UL,
+                selfDeaf: false,
+                selfMute: false,
+                It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        var playerModel = new PlayerInformationModel(
+            GuildId: 0UL,
+            CurrentTrack: null,
+            Volume: 1F,
+            IsPaused: false,
+            VoiceState: CreateVoiceState(),
+            Filters: new PlayerFilterMapModel());
+
+        var options = new LavalinkPlayerOptions
+        {
+            EnableVoiceAutoReconnect = true,
+            VoiceReconnectCooldown = TimeSpan.FromSeconds(10),
+            SelfDeaf = false,
+            SelfMute = false,
+        };
+
+        var playerProperties = CreateProperties(playerModel: playerModel, options: options, discordClientMock: discordClientMock);
+        var player = new LavalinkPlayer(playerProperties);
+
+        // Ensure we have a voice channel to re-assert.
+        var listener = (ILavalinkPlayerListener)player;
+        await listener.NotifyVoiceStateUpdatedAsync(new VoiceState(VoiceChannelId: 42UL, SessionId: "abc"));
+
+        // Act
+        await listener.NotifyWebSocketClosedAsync((WebSocketCloseStatus)4015, "Voice server crashed.", byRemote: true);
+
+        // Assert
+        discordClientMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task TestVoiceAutoReconnectIsSuppressedWhenDisabledAsync()
+    {
+        // Arrange
+        var discordClientMock = new Mock<IDiscordClientWrapper>(MockBehavior.Strict);
+        var playerModel = new PlayerInformationModel(
+            GuildId: 0UL,
+            CurrentTrack: null,
+            Volume: 1F,
+            IsPaused: false,
+            VoiceState: CreateVoiceState(),
+            Filters: new PlayerFilterMapModel());
+
+        var options = new LavalinkPlayerOptions
+        {
+            EnableVoiceAutoReconnect = false,
+            VoiceReconnectCooldown = TimeSpan.FromSeconds(10),
+            SelfDeaf = false,
+            SelfMute = false,
+        };
+
+        var playerProperties = CreateProperties(playerModel: playerModel, options: options, discordClientMock: discordClientMock);
+        var player = new LavalinkPlayer(playerProperties);
+        var listener = (ILavalinkPlayerListener)player;
+        await listener.NotifyVoiceStateUpdatedAsync(new VoiceState(VoiceChannelId: 42UL, SessionId: "abc"));
+
+        // Act
+        await listener.NotifyWebSocketClosedAsync((WebSocketCloseStatus)4014, "Disconnected.", byRemote: true);
+
+        // Assert
+        discordClientMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task TestVoiceAutoReconnectIsRateLimitedByCooldownAsync()
+    {
+        // Arrange
+        var discordClientMock = new Mock<IDiscordClientWrapper>(MockBehavior.Strict);
+
+        discordClientMock
+            .Setup(x => x.SendVoiceUpdateAsync(
+                guildId: 0UL,
+                voiceChannelId: 42UL,
+                selfDeaf: false,
+                selfMute: false,
+                It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask)
+            .Verifiable();
+
+        var playerModel = new PlayerInformationModel(
+            GuildId: 0UL,
+            CurrentTrack: null,
+            Volume: 1F,
+            IsPaused: false,
+            VoiceState: CreateVoiceState(),
+            Filters: new PlayerFilterMapModel());
+
+        var options = new LavalinkPlayerOptions
+        {
+            EnableVoiceAutoReconnect = true,
+            VoiceReconnectCooldown = TimeSpan.FromMinutes(1),
+            SelfDeaf = false,
+            SelfMute = false,
+        };
+
+        var playerProperties = CreateProperties(playerModel: playerModel, options: options, discordClientMock: discordClientMock);
+        var player = new LavalinkPlayer(playerProperties);
+        var listener = (ILavalinkPlayerListener)player;
+        await listener.NotifyVoiceStateUpdatedAsync(new VoiceState(VoiceChannelId: 42UL, SessionId: "abc"));
+
+        // Act
+        await listener.NotifyWebSocketClosedAsync((WebSocketCloseStatus)4014, "Disconnected.", byRemote: true);
+        await listener.NotifyWebSocketClosedAsync((WebSocketCloseStatus)4014, "Disconnected.", byRemote: true);
+
+        // Assert
+        discordClientMock.Verify(x => x.SendVoiceUpdateAsync(0UL, 42UL, false, false, It.IsAny<CancellationToken>()), Times.Once);
+        discordClientMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task TestVoiceAutoReconnectCooldownIsThreadSafeAsync()
+    {
+        // Arrange
+        var discordClientMock = new Mock<IDiscordClientWrapper>(MockBehavior.Strict);
+
+        discordClientMock
+            .Setup(x => x.SendVoiceUpdateAsync(
+                guildId: 0UL,
+                voiceChannelId: 42UL,
+                selfDeaf: false,
+                selfMute: false,
+                It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        var playerModel = new PlayerInformationModel(
+            GuildId: 0UL,
+            CurrentTrack: null,
+            Volume: 1F,
+            IsPaused: false,
+            VoiceState: CreateVoiceState(),
+            Filters: new PlayerFilterMapModel());
+
+        var options = new LavalinkPlayerOptions
+        {
+            EnableVoiceAutoReconnect = true,
+            VoiceReconnectCooldown = TimeSpan.FromMinutes(5),
+            SelfDeaf = false,
+            SelfMute = false,
+        };
+
+        var playerProperties = CreateProperties(playerModel: playerModel, options: options, discordClientMock: discordClientMock);
+        var player = new LavalinkPlayer(playerProperties);
+        var listener = (ILavalinkPlayerListener)player;
+        await listener.NotifyVoiceStateUpdatedAsync(new VoiceState(VoiceChannelId: 42UL, SessionId: "abc"));
+
+        // Act
+        await Task.WhenAll(
+            listener.NotifyWebSocketClosedAsync((WebSocketCloseStatus)4014, "Disconnected.", byRemote: true).AsTask(),
+            listener.NotifyWebSocketClosedAsync((WebSocketCloseStatus)4014, "Disconnected.", byRemote: true).AsTask());
+
+        // Assert
+        discordClientMock.Verify(x => x.SendVoiceUpdateAsync(0UL, 42UL, false, false, It.IsAny<CancellationToken>()), Times.Once);
+        discordClientMock.VerifyNoOtherCalls();
     }
 
     [Fact]
@@ -826,7 +1042,8 @@ public sealed class LavalinkPlayerTests
         PlayerInformationModel playerModel,
         PlayerInformationModel? mutatedPlayerModel = null,
         LavalinkPlayerOptions? options = null,
-        Action<PlayerUpdateProperties>? updateAction = null)
+        Action<PlayerUpdateProperties>? updateAction = null,
+        Mock<IDiscordClientWrapper>? discordClientMock = null)
     {
         var sessionId = "abc";
         var apiClientMock = new Mock<ILavalinkApiClient>(MockBehavior.Strict);
@@ -844,7 +1061,7 @@ public sealed class LavalinkPlayerTests
             .Setup(x => x.DestroyPlayerAsync("abc", 0, It.IsAny<CancellationToken>()))
             .Returns(ValueTask.CompletedTask);
 
-        var discordClientMock = new Mock<IDiscordClientWrapper>();
+        discordClientMock ??= new Mock<IDiscordClientWrapper>();
 
         var sessionProvider = Mock.Of<ILavalinkSessionProvider>(x
             => x.GetSessionAsync(playerModel.GuildId, It.IsAny<CancellationToken>())


### PR DESCRIPTION
## Problem
When Discord forces a gateway reconnect (observed with DSharpPlus nightly), Lavalink can emit a `WebSocketClosedEvent` for the voice websocket with close code `4014` (and sometimes `4015`). After this happens, Lavalink reports the player as `connected: false` and, today, Lavalink4NET only forwards the event to listeners without attempting recovery. In practice the bot can end up leaving voice and not reconnecting on its own.
## What This PR Changes
This PR adds an automatic recovery path inside `LavalinkPlayer`:
- On remote voice websocket close codes `4014` (Disconnected) and `4015` (Voice server crashed), Lavalink4NET re-asserts the existing voice connection by re-sending a Discord voice state update to the current channel.
- The rejoin uses the player’s configured `SelfDeaf`/`SelfMute`.
- A cooldown is applied to avoid rejoin loops if Discord keeps closing the connection.
Behavior change:
- Recovery is enabled by default; set `EnableVoiceAutoReconnect = false` to preserve the previous behavior.
New options:
- `LavalinkPlayerOptions.EnableVoiceAutoReconnect` (default: `true`)
- `LavalinkPlayerOptions.VoiceReconnectCooldown` (default: `10s`)
## Tests
Adds unit tests covering:
- Rejoin attempt on 4014 and 4015
- Opt-out disables recovery
- Cooldown prevents repeated attempts
- Cooldown behavior is thread-safe under concurrent close events

Refs #200