### PR TITLE
fix: netcord .net version bump and netcord package version bump

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,10 +24,10 @@
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
         <PackageVersion Include="Moq" Version="4.20.72" />
-        <PackageVersion Include="NetCord.Hosting.Services" Version="1.0.0-alpha.448" />
-        <PackageVersion Include="NetCord.Hosting" Version="1.0.0-alpha.448" />
-        <PackageVersion Include="NetCord.Services" Version="1.0.0-alpha.448" />
-        <PackageVersion Include="NetCord" Version="1.0.0-alpha.448" />
+        <PackageVersion Include="NetCord.Hosting.Services" Version="1.0.0-beta.7" />
+        <PackageVersion Include="NetCord.Hosting" Version="1.0.0-beta.7" />
+        <PackageVersion Include="NetCord.Services" Version="1.0.0-beta.7" />
+        <PackageVersion Include="NetCord" Version="1.0.0-beta.7" />
         <PackageVersion Include="Remora.Discord.Commands" Version="30.0.0" />
         <PackageVersion Include="Remora.Discord.Hosting" Version="7.0.1" />
         <PackageVersion Include="Remora.Discord" Version="2025.2.0" />

--- a/samples/Lavalink4NET.Samples.NetCord/Lavalink4NET.Samples.NetCord.csproj
+++ b/samples/Lavalink4NET.Samples.NetCord/Lavalink4NET.Samples.NetCord.csproj
@@ -10,10 +10,10 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-        <PackageReference Include="NetCord" Version="1.0.0-alpha.448" />
-        <PackageReference Include="NetCord.Hosting" Version="1.0.0-alpha.448" />
-        <PackageReference Include="NetCord.Hosting.Services" Version="1.0.0-alpha.448" />
-        <PackageReference Include="NetCord.Services" Version="1.0.0-alpha.448" />
+        <PackageReference Include="NetCord" Version="1.0.0-beta.7" />
+        <PackageReference Include="NetCord.Hosting" Version="1.0.0-beta.7" />
+        <PackageReference Include="NetCord.Hosting.Services" Version="1.0.0-beta.7" />
+        <PackageReference Include="NetCord.Services" Version="1.0.0-beta.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Lavalink4NET.NetCord/Lavalink4NET.NetCord.csproj
+++ b/src/Lavalink4NET.NetCord/Lavalink4NET.NetCord.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks>net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         
         <!-- Package Description -->


### PR DESCRIPTION
This PR aims at fixing an exception caused by the latest internal JoinVoiceChannel changes made in NetCord.
Netcord packages have been bumped to latest beta version from alpha and also the target framework has been bumped from
.NET 9 to .NET 10